### PR TITLE
Add all photos to "albums" table

### DIFF
--- a/azurephotos/src/api/albums.py
+++ b/azurephotos/src/api/albums.py
@@ -28,6 +28,7 @@ api_albums_controller = Blueprint(
 )
 
 DEFAULT_ALBUM_THUMBNAIL: str = "/static/photo_album-512.webp"
+NONE_ALBUM_NAME = "__NONE__"
 
 
 @api_albums_controller.route("/<album_name>", methods=["POST"])
@@ -37,6 +38,9 @@ def create_album(album_name: str) -> Response | dict[str, Any]:
 
     :param album_name: The name of the album to create. Must be unique.
     """
+
+    if album_name == NONE_ALBUM_NAME:
+        return Response(f"Album name {NONE_ALBUM_NAME} is reserved", status=403)
 
     account_name: str = current_app.config["account_name"]
     table_name: str = current_app.config["albums_table_name"]
@@ -78,7 +82,9 @@ def _list_albums(account_name: str, table_name: str, credential: DefaultAzureCre
 
     table_client: TableClient = get_table_client(account_name, table_name, credential)
 
-    entities = table_client.query_entities(query_filter="RowKey eq ''")
+    query = "PartitionKey ne @reserved_album_name and RowKey eq ''"
+    parameters = {"reserved_album_name": NONE_ALBUM_NAME}
+    entities = table_client.query_entities(query_filter=query, parameters=parameters)
     return [row["PartitionKey"] for row in entities]
 
 
@@ -95,6 +101,9 @@ def rename_album(album_name: str, new_name: str) -> Response:
     Since we can't actually update the partition key, we create a copy of the
     old album with the new name and then delete the old album.
     """
+
+    if album_name == NONE_ALBUM_NAME:
+        return Response(f"Album '{NONE_ALBUM_NAME}' is reserved and cannot be renamed", status=403)
 
     account_name: str = current_app.config["account_name"]
     table_name: str = current_app.config["albums_table_name"]
@@ -118,13 +127,16 @@ def rename_album(album_name: str, new_name: str) -> Response:
 
 @api_albums_controller.route("<album_name>", methods=["DELETE"])
 @invalidates_media_cache
-def delete_album(album_name: str):
+def delete_album(album_name: str) -> Response:
     """
     Delete an album.
     This does not delete the photos in the album.
 
     :param album_name: The name of the album to delete.
     """
+
+    if album_name == NONE_ALBUM_NAME:
+        return Response(f"Album name '{NONE_ALBUM_NAME}' is reserved and cannot be deleted", status=403)
 
     account_name: str = current_app.config["account_name"]
     table_name: str = current_app.config["albums_table_name"]
@@ -143,7 +155,7 @@ def delete_album(album_name: str):
 
 @api_albums_controller.route("<album_name>/<filename>", methods=["POST"])
 @invalidates_media_cache
-def add_to_album(album_name: str, filename: str) -> Response | dict[str, Any]:
+def add_to_album(album_name: str, filename: str) -> Response:
     """
     Add a file to an album.
 
@@ -156,17 +168,33 @@ def add_to_album(album_name: str, filename: str) -> Response | dict[str, Any]:
     credential: DefaultAzureCredential = current_app.config["credential"]
     table_client: TableClient = get_table_client(account_name, table_name, credential)
 
-    try:
-        table_client.get_entity(partition_key=album_name, row_key="")
-    except ResourceNotFoundError:
-        return Response("Album does not exist", status=404)
+    if album_name == NONE_ALBUM_NAME: # First upload
+        new_file = {
+            "PartitionKey": album_name,
+            "RowKey": filename,
+            "Created": datetime.now(timezone.utc)
+        }
+        _ = table_client.create_entity(new_file)
+    else:
+        try:
+            non_album_entity = table_client.get_entity(partition_key=NONE_ALBUM_NAME, row_key=filename)
+        except ResourceNotFoundError:
+            return Response(f"Filename '{filename}' does not exist or is already in an album")
+        
+        try:
+            _ = table_client.get_entity(partition_key=album_name, row_key="")
+        except ResourceNotFoundError:
+            return Response(f"Album '{album_name}' does not exist", status=404)
 
-    new_file = {
-        "PartitionKey": album_name,
-        "RowKey": filename,
-        "Created": datetime.now(timezone.utc),
-    }
-    return table_client.create_entity(new_file)  # type: ignore
+        # Add new entity to album
+        new_file = dict(non_album_entity)
+        new_file["PartitionKey"] = album_name
+        _ = table_client.create_entity(new_file) 
+
+        # Delete existing entity
+        _ = table_client.delete_entity(partition_key=NONE_ALBUM_NAME, row_key=filename)
+
+    return Response(status=201)
 
 
 @api_albums_controller.route("<album_name>", methods=["GET"])
@@ -224,12 +252,24 @@ def remove_from_album(album_name: str, filename: str) -> Response:
     :param filename: The filename of the photo to remove from the album.
     """
 
+    if album_name == NONE_ALBUM_NAME:
+        return Response(f"Album name '{NONE_ALBUM_NAME}' is reserved and cannot be deleted from")
+
     account_name: str = current_app.config["account_name"]
     table_name: str = current_app.config["albums_table_name"]
     credential: DefaultAzureCredential = current_app.config["credential"]
     table_client: TableClient = get_table_client(account_name, table_name, credential)
 
-    table_client.delete_entity(partition_key=album_name, row_key=filename)
+    # Get existing entity
+    existing_entity = table_client.get_entity(partition_key=album_name, row_key=filename)
+    
+    # Add new entity to NONE album
+    new_entity = dict(existing_entity)
+    new_entity["PartitionKey"] = NONE_ALBUM_NAME
+    _ = table_client.create_entity(new_entity)
+
+    # Delete old entity
+    _ = table_client.delete_entity(partition_key=album_name, row_key=filename)
     return Response(status=204)
 
 
@@ -291,13 +331,30 @@ def remove_from_all_albums(filename: str) -> None:
 
 
 @refreshed(every=timedelta(seconds=30))
-def all_album_file_names(account_name: str, table_name: str, credential: DefaultAzureCredential) -> list[str]:
+def non_album_file_names(account_name: str, table_name: str, credential: DefaultAzureCredential) -> list[MediaRecord]:
     """
-    List all photo names in all albums.
-    Note that photos in multiple albums will be listed multiple times.
+    Get all entities not in an album
     """
-
+    
     table_client: TableClient = get_table_client(account_name, table_name, credential)
 
-    entities = table_client.query_entities(query_filter="RowKey ne ''")
-    return [row["RowKey"] for row in entities]
+    query = "PartitionKey eq @reserved_album_name and RowKey ne ''"
+    parameters = {"reserved_album_name": NONE_ALBUM_NAME}
+    entities = table_client.query_entities(query_filter=query, parameters=parameters)
+
+    results = list[MediaRecord]()
+    for row in entities:
+        filename = row["RowKey"]
+        last_modified = row["Created"]
+
+        match (media_type_from_file_extension(filename)):
+            case MediaType.PHOTO:
+                result = PhotoRecord(last_modified, filename)
+            case MediaType.VIDEO:
+                result = VideoRecord(last_modified, filename)
+            case _:
+                raise Exception(f"Unknown media type")
+        
+        results.append(result)
+
+    return results

--- a/azurephotos/src/api/albums.py
+++ b/azurephotos/src/api/albums.py
@@ -163,37 +163,53 @@ def add_to_album(album_name: str, filename: str) -> Response:
     :param filename: The filename to add to the album.
     """
 
+    if album_name == NONE_ALBUM_NAME:
+        return Response(f"Album name '{NONE_ALBUM_NAME}' is reserved and cannot be added to directly")
+
     account_name: str = current_app.config["account_name"]
     table_name: str = current_app.config["albums_table_name"]
     credential: DefaultAzureCredential = current_app.config["credential"]
     table_client: TableClient = get_table_client(account_name, table_name, credential)
 
-    if album_name == NONE_ALBUM_NAME: # First upload
-        new_file = {
-            "PartitionKey": album_name,
-            "RowKey": filename,
-            "Created": datetime.now(timezone.utc)
-        }
-        _ = table_client.create_entity(new_file)
-    else:
-        try:
-            non_album_entity = table_client.get_entity(partition_key=NONE_ALBUM_NAME, row_key=filename)
-        except ResourceNotFoundError:
-            return Response(f"Filename '{filename}' does not exist or is already in an album")
-        
-        try:
-            _ = table_client.get_entity(partition_key=album_name, row_key="")
-        except ResourceNotFoundError:
-            return Response(f"Album '{album_name}' does not exist", status=404)
+    try:
+        non_album_entity = table_client.get_entity(partition_key=NONE_ALBUM_NAME, row_key=filename)
+    except ResourceNotFoundError:
+        return Response(f"Filename '{filename}' does not exist or is already in an album")
+    
+    try:
+        _ = table_client.get_entity(partition_key=album_name, row_key="")
+    except ResourceNotFoundError:
+        return Response(f"Album '{album_name}' does not exist", status=404)
 
-        # Add new entity to album
-        new_file = dict(non_album_entity)
-        new_file["PartitionKey"] = album_name
-        _ = table_client.create_entity(new_file) 
+    # Add new entity to album
+    new_file = dict(non_album_entity)
+    new_file["PartitionKey"] = album_name
+    _ = table_client.create_entity(new_file) 
 
-        # Delete existing entity
-        _ = table_client.delete_entity(partition_key=NONE_ALBUM_NAME, row_key=filename)
+    # Delete existing entity
+    _ = table_client.delete_entity(partition_key=NONE_ALBUM_NAME, row_key=filename)
 
+    return Response(status=201)
+
+@invalidates_media_cache
+def _add_to_reserved_album(filename: str, date_taken: datetime) -> Response:
+    """
+    Add a photo to the "none album" album.
+    Should only be used when first uploading a photo.
+    """
+    
+    account_name: str = current_app.config["account_name"]
+    table_name: str = current_app.config["albums_table_name"]
+    credential: DefaultAzureCredential = current_app.config["credential"]
+    table_client: TableClient = get_table_client(account_name, table_name, credential)
+
+    new_file = {
+        "PartitionKey": NONE_ALBUM_NAME,
+        "RowKey": filename,
+        "Created": date_taken
+    }
+    _ = table_client.create_entity(new_file)
+    
     return Response(status=201)
 
 

--- a/azurephotos/src/api/albums.py
+++ b/azurephotos/src/api/albums.py
@@ -254,7 +254,11 @@ def list_album(album_name: str) -> Response | list[MediaRecord]:
     if not album_exists:
         return Response("Album does not exist", status=404)
     
-    return medias
+    return sorted(
+        medias,
+        key=lambda m: m.last_modified,
+        reverse=True
+    )
 
 
 @api_albums_controller.route("<album_name>/<filename>", methods=["DELETE"])

--- a/azurephotos/src/api/crud_controller.py
+++ b/azurephotos/src/api/crud_controller.py
@@ -4,6 +4,7 @@ Will delegate to the proper controller per media.
 """
 
 from azure.identity import DefaultAzureCredential
+from datetime import datetime
 from flask import Blueprint, redirect, current_app, request
 from werkzeug.wrappers.response import Response
 from werkzeug.datastructures.file_storage import FileStorage
@@ -15,7 +16,7 @@ from .media_cache import invalidates_media_cache
 from ..lib.storage_helper import get_container_sas
 from ..lib.models.media import MediaType, media_type_from_file_extension
 
-from .albums import remove_from_all_albums, add_to_album, NONE_ALBUM_NAME
+from .albums import remove_from_all_albums, add_to_album, _add_to_reserved_album, NONE_ALBUM_NAME
 
 crud_controller = Blueprint(
     "crud_controller",
@@ -112,7 +113,7 @@ def _upload(*file_infos: tuple[FileStorage, str]) -> list[str]:
                 raise ValueError(f"Unrecognized media type for {file.filename=}")
         
         uploaded_filenames.append(uploaded_filename)
-        _ = add_to_album(NONE_ALBUM_NAME, uploaded_filename)
+        _ = _add_to_reserved_album(uploaded_filename, datetime.fromisoformat(date_taken))
 
     return uploaded_filenames
 

--- a/azurephotos/src/api/crud_controller.py
+++ b/azurephotos/src/api/crud_controller.py
@@ -15,7 +15,7 @@ from .media_cache import invalidates_media_cache
 from ..lib.storage_helper import get_container_sas
 from ..lib.models.media import MediaType, media_type_from_file_extension
 
-from .albums import remove_from_all_albums, add_to_album
+from .albums import remove_from_all_albums, add_to_album, NONE_ALBUM_NAME
 
 crud_controller = Blueprint(
     "crud_controller",
@@ -102,15 +102,17 @@ def _upload(*file_infos: tuple[FileStorage, str]) -> list[str]:
     uploaded_filenames = list[str]()
     for file, date_taken in file_infos:
         media_type = media_type_from_file_extension(file.filename)
+        uploaded_filename = None
         match media_type:
             case MediaType.PHOTO:
-                uploaded_photo = photos.upload((file, date_taken))
-                uploaded_filenames.append(uploaded_photo)
+                uploaded_filename = photos.upload((file, date_taken))
             case MediaType.VIDEO:
-                uploaded_video = videos.upload((file, date_taken))
-                uploaded_filenames.append(uploaded_video)
+                uploaded_filename = videos.upload((file, date_taken))
             case _:
                 raise ValueError(f"Unrecognized media type for {file.filename=}")
+        
+        uploaded_filenames.append(uploaded_filename)
+        _ = add_to_album(NONE_ALBUM_NAME, uploaded_filename)
 
     return uploaded_filenames
 
@@ -121,6 +123,9 @@ def upload_to_album(album_name: str) -> Response:
     """
     Upload photos or videos, and add it to an album.
     """
+
+    if album_name == NONE_ALBUM_NAME:
+        return Response(f"Album name '{NONE_ALBUM_NAME}' is reserved and cannot be uploaded to directly", status=403)
 
     files = request.files.getlist("upload")
     dates_taken = request.form.getlist("dateTaken")
@@ -135,11 +140,7 @@ def upload_to_album(album_name: str) -> Response:
     uploaded_filenames = _upload(*zip(files, dates_taken))
     for uploaded_filename in uploaded_filenames:
         add_to_album_result = add_to_album(album_name, uploaded_filename)
-
-        if (
-            isinstance(add_to_album_result, Response)
-            and add_to_album_result.status_code >= 400
-        ):
+        if add_to_album_result.status_code >= 400:
             # TODO: Should we instead aggregate results at the end?
             return add_to_album_result
 

--- a/azurephotos/src/api/media_cache.py
+++ b/azurephotos/src/api/media_cache.py
@@ -1,5 +1,4 @@
 from azure.identity import DefaultAzureCredential
-from concurrent.futures import ThreadPoolExecutor
 from flask import current_app
 from functools import wraps
 from typing import Sequence
@@ -10,10 +9,7 @@ from ..lib.models.media import MediaRecord
 media_cache: Sequence[MediaRecord] | None = None
 
 def all_media() -> Sequence[MediaRecord]:
-    from .photos import all_photos
-    from .videos import all_videos
-    from .albums import all_album_file_names
-    from ..lib.sorting import merge
+    from .albums import non_album_file_names
     global media_cache
 
     if media_cache is not None:
@@ -23,27 +19,11 @@ def all_media() -> Sequence[MediaRecord]:
     print("RECALCULATING MEDIA")
     
     account_name: str = current_app.config["account_name"]
-    photos_container_name: str = current_app.config["photos_container_name"]
-    videos_container_name: str = current_app.config["videos_container_name"]
     table_name: str = current_app.config["albums_table_name"]
     credential: DefaultAzureCredential = current_app.config["credential"]
 
-    with ThreadPoolExecutor() as executor:
-        photos_future = executor.submit(all_photos, account_name, photos_container_name, credential)
-        videos_future = executor.submit(all_videos, account_name, videos_container_name, credential)
-        album_file_names_future = executor.submit(all_album_file_names, account_name, table_name, credential)
-
-        photos_result = photos_future.result()
-        videos_result = videos_future.result()    
-        album_file_names = set(album_file_names_future.result())
-    
-    non_album_photos = [photo for photo in photos_result if photo.filename not in album_file_names]
-    non_album_videos = [video for video in videos_result if video.filename not in album_file_names]
-    media_cache = merge(
-        non_album_photos, non_album_videos,
-        key=lambda m: m.last_modified,
-        reverse=True)
-    
+    # TODO: Fix ordering, which is ruined when using 'Created' in a table
+    media_cache = non_album_file_names(account_name, table_name, credential)
     return media_cache
 
 def invalidates_media_cache(func):

--- a/azurephotos/src/api/media_cache.py
+++ b/azurephotos/src/api/media_cache.py
@@ -22,8 +22,10 @@ def all_media() -> Sequence[MediaRecord]:
     table_name: str = current_app.config["albums_table_name"]
     credential: DefaultAzureCredential = current_app.config["credential"]
 
-    # TODO: Fix ordering, which is ruined when using 'Created' in a table
-    media_cache = non_album_file_names(account_name, table_name, credential)
+    media_cache = sorted(
+        non_album_file_names(account_name, table_name, credential),
+        key= lambda m: m.last_modified,
+        reverse=True)
     return media_cache
 
 def invalidates_media_cache(func):

--- a/azurephotos/src/view/view.py
+++ b/azurephotos/src/view/view.py
@@ -2,7 +2,7 @@ from concurrent.futures import ThreadPoolExecutor
 from flask import Blueprint, render_template, Response, current_app
 from flask.ctx import AppContext
 
-from ..api.albums import list_albums, list_album#, all_album_file_names
+from ..api.albums import list_albums, list_album
 from ..api.media_cache import all_media
 
 landing_view_controller = Blueprint(


### PR DESCRIPTION
This change expands the use of the albums table to cover all uploaded photos and videos, not just those in albums. Photos that are not currently in albums will have a PartitionKey of `__NONE__`, a sentinel value. This change allows us to more efficiently calculate the main page of all photos not in an album by a simple table query, rather than the previous process of listing all blobs, all blobs in an album, and taking the difference. We now use the table's 'Created' column to sort the entries rather than the blob's last_modified.