### PR TITLE
Add cache control for static files

### DIFF
--- a/azurephotos/app.py
+++ b/azurephotos/app.py
@@ -15,6 +15,7 @@ def create_app() -> Flask:
             videos_container_name="videos",
             albums_table_name="Albums2",
         )
+        app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 86400
 
         for blueprint in view.blueprints:
             app.register_blueprint(blueprint)


### PR DESCRIPTION
This should set a Cache-Control max-age of 86400 (1 day), which should prevent the browser from downloading the JS again every time.