### PR TITLE
Improve Upload Performance

### DIFF
--- a/azurephotos/app.py
+++ b/azurephotos/app.py
@@ -1,5 +1,7 @@
 from flask import Flask
 from azure.identity import DefaultAzureCredential
+from azure.storage.blob import BlobServiceClient
+from azure.data.tables import TableServiceClient
 import src.view.view as view
 import src.api.api as api
 
@@ -7,16 +9,32 @@ def create_app() -> Flask:
     app = Flask(__name__)
 
     with app.app_context():
-        app.config.update(
-            credential=DefaultAzureCredential(exclude_cli_credential=True),
-            account_name="wboylesbackups",
-            thumbnails_container_name="thumbnails",
-            photos_container_name="photos",
-            videos_container_name="videos",
-            albums_table_name="Albums2",
-        )
-        app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 86400
+        credential = DefaultAzureCredential(exclude_cli_credential=True)
+        account_name = "wboylesbackups"
 
+        blob_account_url = f"https://{account_name}.blob.core.windows.net"
+        blob_service_client = BlobServiceClient(blob_account_url, credential=credential)
+        photos_container_client = blob_service_client.get_container_client("photos")
+        videos_container_client = blob_service_client.get_container_client("videos")
+        thumbnails_container_client = blob_service_client.get_container_client("thumbnails")
+
+        table_account_url = f"https://{account_name}.table.core.windows.net"
+        albums_table_client = TableServiceClient(
+            table_account_url, credential=credential
+        ).get_table_client("Albums2")
+
+        app.config.update(
+            credential=credential,
+            account_name=account_name,
+            blob_account_url=blob_account_url,
+            blob_service_client=blob_service_client,
+            photos_container_client=photos_container_client,
+            videos_container_client=videos_container_client,
+            thumbnails_container_client=thumbnails_container_client,
+            albums_table_client=albums_table_client,
+            SEND_FILE_MAX_AGE_DEFAULT=86400,
+            MAX_CONTENT_LENGTH=200 * 1024 * 1024,  # 200 MB
+        )
         for blueprint in view.blueprints:
             app.register_blueprint(blueprint)
         for blueprint in api.blueprints:

--- a/azurephotos/src/api/albums.py
+++ b/azurephotos/src/api/albums.py
@@ -303,7 +303,7 @@ def list_album(album_name: str) -> Response | list[MediaRecord]:
 @invalidates_media_cache
 def remove_from_album(album_name: str, filename: str) -> Response:
     """
-    Remove a photo from an album.
+    Remove a photo from an album, putting it back in the "none" album.
     This does not remove the photo itself or remove it from other albums.
 
     :param album_name: The name of the album to remove the photo from.

--- a/azurephotos/src/api/albums.py
+++ b/azurephotos/src/api/albums.py
@@ -310,9 +310,12 @@ def remove_from_album(album_name: str, filename: str) -> Response:
     table_client: TableClient = current_app.config["albums_table_client"]
 
     # Get existing entity
-    existing_entity = table_client.get_entity(
-        partition_key=album_name, row_key=filename
-    )
+    try:
+        existing_entity = table_client.get_entity(
+            partition_key=album_name, row_key=filename
+        )
+    except ResourceNotFoundError:
+        return Response(f"'{filename}' not found in album '{album_name}'", status=404)
 
     # Add new entity to NONE album
     new_entity = dict(existing_entity)

--- a/azurephotos/src/api/albums.py
+++ b/azurephotos/src/api/albums.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone, timedelta
 from flask import Blueprint, Response, current_app, url_for, redirect
 from typing import Any
 
-from .media_cache import invalidates_media_cache
+from .media_cache import invalidate_media_cache
 from ..lib.storage_helper import TableClient, get_table_client
 from ..lib.refresher import refreshed
 from ..lib.models.media import MediaRecord
@@ -135,11 +135,10 @@ def rename_album(album_name: str, new_name: str) -> Response:
 
 
 @api_albums_controller.route("<album_name>", methods=["DELETE"])
-@invalidates_media_cache
 def delete_album(album_name: str) -> Response:
     """
     Delete an album.
-    This does not delete the photos in the album.
+    Entries in the album will be moved to the "none" album.
 
     :param album_name: The name of the album to delete.
     """
@@ -175,12 +174,12 @@ def delete_album(album_name: str) -> Response:
 
     if not entity:  # No results. Loop didn't run
         return Response(f"Album '{album_name}' not found", status=404)
-
+    
+    invalidate_media_cache()
     return Response(status=204)
 
 
 @api_albums_controller.route("<album_name>/<filename>", methods=["POST"])
-@invalidates_media_cache
 def move_to_album(album_name: str, filename: str) -> Response:
     """
     Move an existing file from the "none" album to another album.
@@ -227,10 +226,11 @@ def move_to_album(album_name: str, filename: str) -> Response:
         # Entry already deleted
         pass
 
+    invalidate_media_cache()
     return Response(status=201)
 
 
-@invalidates_media_cache
+# Don't invalidate media cache. Caller will decide if they want to do that.
 def upload_to_album(filename: str, date_taken: datetime, album_name: str) -> Response:
     """
     Upload a photo directly to an album.
@@ -300,7 +300,6 @@ def list_album(album_name: str) -> Response | list[MediaRecord]:
 
 
 @api_albums_controller.route("<album_name>/<filename>", methods=["DELETE"])
-@invalidates_media_cache
 def remove_from_album(album_name: str, filename: str) -> Response:
     """
     Remove a photo from an album, putting it back in the "none" album.
@@ -337,6 +336,7 @@ def remove_from_album(album_name: str, filename: str) -> Response:
         # Entry already removed
         pass
 
+    invalidate_media_cache()
     return Response(status=204)
 
 
@@ -372,13 +372,14 @@ def get_album_thumbnail(album_name: str) -> Response:
     return response  # type: ignore
 
 
-@invalidates_media_cache
-def remove_from_all_albums(filename: str) -> None:
+# Don't invalidate media cache. Caller will decide if they want to do that.
+def remove_from_all_albums(filename: str) -> set[str]:
     """
     Remove an entry from all albums.
     Most likely used when deleting an entry.
 
     :param filename: The filename of the entry to remove.
+    :return: The set of albums that were affected by the removal.
     """
 
     account_name: str = current_app.config["account_name"]
@@ -389,12 +390,16 @@ def remove_from_all_albums(filename: str) -> None:
     query = "RowKey eq @filename"
     parameters = {"filename": filename}
     entities = table_client.query_entities(query_filter=query, parameters=parameters)
+    albums_affected = set[str]()
     for entity in entities:
         try:
             table_client.delete_entity(entity)
+            albums_affected.add(entity["PartitionKey"])
         except ResourceNotFoundError:
             # Entry already deleted
             pass
+
+    return albums_affected
 
 
 @refreshed(every=timedelta(seconds=30))

--- a/azurephotos/src/api/albums.py
+++ b/azurephotos/src/api/albums.py
@@ -9,13 +9,12 @@ An empty row key represents the album itself.
 """
 
 from azure.core.exceptions import ResourceNotFoundError, ResourceExistsError
-from azure.identity import DefaultAzureCredential
+from azure.data.tables import TableClient
 from datetime import datetime, timezone, timedelta
 from flask import Blueprint, Response, current_app, url_for, redirect
 from typing import Any
 
 from .media_cache import invalidate_media_cache
-from ..lib.storage_helper import TableClient, get_table_client
 from ..lib.refresher import refreshed
 from ..lib.models.media import MediaRecord
 
@@ -42,10 +41,7 @@ def create_album(album_name: str) -> Response | dict[str, Any]:
     if album_name == NONE_ALBUM_NAME:
         return Response(f"Album name {NONE_ALBUM_NAME} is reserved", status=403)
 
-    account_name: str = current_app.config["account_name"]
-    table_name: str = current_app.config["albums_table_name"]
-    credential: DefaultAzureCredential = current_app.config["credential"]
-    table_client: TableClient = get_table_client(account_name, table_name, credential)
+    table_client = current_app.config["albums_table_client"]
 
     new_album = {
         "PartitionKey": album_name,
@@ -65,24 +61,17 @@ def list_albums() -> list[str]:
     List all album names.
     """
 
-    account_name: str = current_app.config["account_name"]
-    table_name: str = current_app.config["albums_table_name"]
-    credential: DefaultAzureCredential = current_app.config["credential"]
-
-    return _list_albums(account_name, table_name, credential)
+    return _list_albums()
 
 
 @refreshed(every=timedelta(seconds=30))
-def _list_albums(
-    account_name: str, table_name: str, credential: DefaultAzureCredential
-) -> list[str]:
+def _list_albums() -> list[str]:
+
     """
     List all album names.
     """
 
-    print("LISTING ALBUMS")
-
-    table_client: TableClient = get_table_client(account_name, table_name, credential)
+    table_client: TableClient = current_app.config["albums_table_client"]
 
     query = "PartitionKey ne @reserved_album_name and RowKey eq ''"
     parameters = {"reserved_album_name": NONE_ALBUM_NAME}
@@ -109,10 +98,7 @@ def rename_album(album_name: str, new_name: str) -> Response:
             f"Album '{NONE_ALBUM_NAME}' is reserved and cannot be renamed", status=403
         )
 
-    account_name: str = current_app.config["account_name"]
-    table_name: str = current_app.config["albums_table_name"]
-    credential: DefaultAzureCredential = current_app.config["credential"]
-    table_client: TableClient = get_table_client(account_name, table_name, credential)
+    table_client: TableClient = current_app.config["albums_table_client"]
 
     query = "PartitionKey eq @album_name"
     parameters = {"album_name": album_name}
@@ -149,10 +135,7 @@ def delete_album(album_name: str) -> Response:
             status=403,
         )
 
-    account_name: str = current_app.config["account_name"]
-    table_name: str = current_app.config["albums_table_name"]
-    credential: DefaultAzureCredential = current_app.config["credential"]
-    table_client: TableClient = get_table_client(account_name, table_name, credential)
+    table_client: TableClient = current_app.config["albums_table_client"]
 
     query = "PartitionKey eq @album_name"
     parameters = {"album_name": album_name}
@@ -194,10 +177,7 @@ def move_to_album(album_name: str, filename: str) -> Response:
             f"Album name '{NONE_ALBUM_NAME}' is reserved and cannot be added to directly"
         )
 
-    account_name: str = current_app.config["account_name"]
-    table_name: str = current_app.config["albums_table_name"]
-    credential: DefaultAzureCredential = current_app.config["credential"]
-    table_client: TableClient = get_table_client(account_name, table_name, credential)
+    table_client: TableClient = current_app.config["albums_table_client"]
 
     try:
         non_album_entity = table_client.get_entity(
@@ -245,10 +225,16 @@ def upload_to_album(filename: str, date_taken: datetime, album_name: str) -> Res
     :param album_name: Name of album to add to
     """
 
-    account_name: str = current_app.config["account_name"]
-    table_name: str = current_app.config["albums_table_name"]
-    credential: DefaultAzureCredential = current_app.config["credential"]
-    table_client: TableClient = get_table_client(account_name, table_name, credential)
+    table_client: TableClient = current_app.config["albums_table_client"]
+
+    # Check that album exists
+    # TODO: Could we cache this and avoid checking every time?
+    try:
+        # None album entry doesn't have an empty row key. We can assume it always exists
+        if album_name != NONE_ALBUM_NAME:
+            _ = table_client.get_entity(partition_key=album_name, row_key="")
+    except ResourceNotFoundError:
+        return Response(f"Album '{album_name}' does not exist", status=404)
 
     new_file = {
         "PartitionKey": album_name,
@@ -268,10 +254,7 @@ def list_album(album_name: str) -> Response | list[MediaRecord]:
     :param album_name: The name of the album to list files for.
     """
 
-    account_name: str = current_app.config["account_name"]
-    table_name: str = current_app.config["albums_table_name"]
-    credential: DefaultAzureCredential = current_app.config["credential"]
-    table_client: TableClient = get_table_client(account_name, table_name, credential)
+    table_client: TableClient = current_app.config["albums_table_client"]
 
     query = "PartitionKey eq @album_name"
     parameters = {"album_name": album_name}
@@ -314,10 +297,7 @@ def remove_from_album(album_name: str, filename: str) -> Response:
             f"Album name '{NONE_ALBUM_NAME}' is reserved and cannot be deleted from"
         )
 
-    account_name: str = current_app.config["account_name"]
-    table_name: str = current_app.config["albums_table_name"]
-    credential: DefaultAzureCredential = current_app.config["credential"]
-    table_client: TableClient = get_table_client(account_name, table_name, credential)
+    table_client: TableClient = current_app.config["albums_table_client"]
 
     # Get existing entity
     existing_entity = table_client.get_entity(
@@ -348,10 +328,7 @@ def get_album_thumbnail(album_name: str) -> Response:
     :param album_name: The name of the album to get the thumbnail for.
     """
 
-    account_name: str = current_app.config["account_name"]
-    table_name: str = current_app.config["albums_table_name"]
-    credential: DefaultAzureCredential = current_app.config["credential"]
-    table_client: TableClient = get_table_client(account_name, table_name, credential)
+    table_client: TableClient = current_app.config["albums_table_client"]
 
     query = "PartitionKey eq @album_name and RowKey ne ''"
     parameters = {"album_name": album_name}
@@ -382,10 +359,7 @@ def remove_from_all_albums(filename: str) -> set[str]:
     :return: The set of albums that were affected by the removal.
     """
 
-    account_name: str = current_app.config["account_name"]
-    table_name: str = current_app.config["albums_table_name"]
-    credential: DefaultAzureCredential = current_app.config["credential"]
-    table_client: TableClient = get_table_client(account_name, table_name, credential)
+    table_client: TableClient = current_app.config["albums_table_client"]
 
     query = "RowKey eq @filename"
     parameters = {"filename": filename}
@@ -403,14 +377,12 @@ def remove_from_all_albums(filename: str) -> set[str]:
 
 
 @refreshed(every=timedelta(seconds=30))
-def non_album_file_names(
-    account_name: str, table_name: str, credential: DefaultAzureCredential
-) -> list[MediaRecord]:
+def non_album_file_names() -> list[MediaRecord]:
     """
     Get all entities not in an album
     """
 
-    table_client: TableClient = get_table_client(account_name, table_name, credential)
+    table_client: TableClient = current_app.config["albums_table_client"]
 
     query = "PartitionKey eq @reserved_album_name and RowKey ne ''"
     parameters = {"reserved_album_name": NONE_ALBUM_NAME}

--- a/azurephotos/src/api/albums.py
+++ b/azurephotos/src/api/albums.py
@@ -181,9 +181,10 @@ def delete_album(album_name: str) -> Response:
 
 @api_albums_controller.route("<album_name>/<filename>", methods=["POST"])
 @invalidates_media_cache
-def add_to_album(album_name: str, filename: str) -> Response:
+def move_to_album(album_name: str, filename: str) -> Response:
     """
-    Add a file to an album.
+    Move an existing file from the "none" album to another album.
+    For uploading a new file to an album, use :func:`delete_album`
 
     :param album_name: The name of the album to add the file to.
     :param filename: The filename to add to the album.
@@ -230,10 +231,18 @@ def add_to_album(album_name: str, filename: str) -> Response:
 
 
 @invalidates_media_cache
-def _add_to_reserved_album(filename: str, date_taken: datetime) -> Response:
+def upload_to_album(filename: str, date_taken: datetime, album_name: str) -> Response:
     """
-    Add a photo to the "none album" album.
-    Should only be used when first uploading a photo.
+    Upload a photo directly to an album.
+    For moving photos between albums, see :func:`move_to_album`.
+    
+    Prerequisites:
+    - Album already exists
+    - Photo does not exist in another album, including "none" album
+
+    :param filename: The filename to add to the album
+    :param date_take: When the file was created
+    :param album_name: Name of album to add to
     """
 
     account_name: str = current_app.config["account_name"]
@@ -242,7 +251,7 @@ def _add_to_reserved_album(filename: str, date_taken: datetime) -> Response:
     table_client: TableClient = get_table_client(account_name, table_name, credential)
 
     new_file = {
-        "PartitionKey": NONE_ALBUM_NAME,
+        "PartitionKey": album_name,
         "RowKey": filename,
         "Created": date_taken,
     }

--- a/azurephotos/src/api/albums.py
+++ b/azurephotos/src/api/albums.py
@@ -97,6 +97,10 @@ def rename_album(album_name: str, new_name: str) -> Response:
         return Response(
             f"Album '{NONE_ALBUM_NAME}' is reserved and cannot be renamed", status=403
         )
+    if new_name == NONE_ALBUM_NAME:
+        return Response(
+            f"Album name '{NONE_ALBUM_NAME}' is reserved and cannot be renamed to", status=403
+        )
 
     table_client: TableClient = current_app.config["albums_table_client"]
 

--- a/azurephotos/src/api/albums.py
+++ b/azurephotos/src/api/albums.py
@@ -230,7 +230,7 @@ def upload_to_album(filename: str, date_taken: datetime, album_name: str) -> Res
     - Photo does not exist in another album, including "none" album
 
     :param filename: The filename to add to the album
-    :param date_take: When the file was created
+    :param date_taken: When the file was created
     :param album_name: Name of album to add to
     """
 

--- a/azurephotos/src/api/albums.py
+++ b/azurephotos/src/api/albums.py
@@ -107,6 +107,7 @@ def rename_album(album_name: str, new_name: str) -> Response:
     query = "PartitionKey eq @album_name"
     parameters = {"album_name": album_name}
     entities = table_client.query_entities(query_filter=query, parameters=parameters)
+    entity = None
     for entity in entities:
         photo_copy = {
             "PartitionKey": new_name,
@@ -120,6 +121,9 @@ def rename_album(album_name: str, new_name: str) -> Response:
         except ResourceNotFoundError:
             # Entry already deleted
             pass
+
+    if not entity:  # No results. Loop didn't run
+        return Response(f"Album '{album_name}' not found", status=404)
 
     return Response(status=204)
 

--- a/azurephotos/src/api/albums.py
+++ b/azurephotos/src/api/albums.py
@@ -188,6 +188,7 @@ def move_to_album(album_name: str, filename: str) -> Response:
 
     table_client: TableClient = current_app.config["albums_table_client"]
 
+    # Find file in "none" album
     try:
         non_album_entity = table_client.get_entity(
             partition_key=NONE_ALBUM_NAME, row_key=filename
@@ -198,6 +199,7 @@ def move_to_album(album_name: str, filename: str) -> Response:
             status=404,
         )
 
+    # Find target album
     try:
         _ = table_client.get_entity(partition_key=album_name, row_key="")
     except ResourceNotFoundError:
@@ -206,7 +208,11 @@ def move_to_album(album_name: str, filename: str) -> Response:
     # Add new entity to album
     new_file = dict(non_album_entity)
     new_file["PartitionKey"] = album_name
-    _ = table_client.create_entity(new_file)
+    try:
+        _ = table_client.create_entity(new_file)
+    except ResourceExistsError:
+        # File already exists in album
+        pass
 
     # Delete existing entity
     try:

--- a/azurephotos/src/api/albums.py
+++ b/azurephotos/src/api/albums.py
@@ -114,6 +114,7 @@ def rename_album(album_name: str, new_name: str) -> Response:
     parameters = {"album_name": album_name}
     entities = table_client.query_entities(query_filter=query, parameters=parameters)
     for entity in entities:
+        print(entity["RowKey"])
         photo_copy = {
             "PartitionKey": new_name,
             "RowKey": entity["RowKey"],
@@ -134,8 +135,6 @@ def delete_album(album_name: str) -> Response:
 
     :param album_name: The name of the album to delete.
     """
-
-    print(f"RECEIVED ALBUM NAME {album_name}")
 
     if album_name == NONE_ALBUM_NAME:
         return Response(f"Album name '{NONE_ALBUM_NAME}' is reserved and cannot be deleted", status=403)

--- a/azurephotos/src/api/albums.py
+++ b/azurephotos/src/api/albums.py
@@ -174,7 +174,8 @@ def move_to_album(album_name: str, filename: str) -> Response:
 
     if album_name == NONE_ALBUM_NAME:
         return Response(
-            f"Album name '{NONE_ALBUM_NAME}' is reserved and cannot be added to directly"
+            f"Album name '{NONE_ALBUM_NAME}' is reserved and cannot be added to directly",
+            status=403
         )
 
     table_client: TableClient = current_app.config["albums_table_client"]
@@ -294,7 +295,8 @@ def remove_from_album(album_name: str, filename: str) -> Response:
 
     if album_name == NONE_ALBUM_NAME:
         return Response(
-            f"Album name '{NONE_ALBUM_NAME}' is reserved and cannot be deleted from"
+            f"Album name '{NONE_ALBUM_NAME}' is reserved and cannot be deleted from",
+            status=403
         )
 
     table_client: TableClient = current_app.config["albums_table_client"]

--- a/azurephotos/src/api/albums.py
+++ b/azurephotos/src/api/albums.py
@@ -128,7 +128,7 @@ def rename_album(album_name: str, new_name: str) -> Response:
     return Response(status=204)
 
 
-@api_albums_controller.route("<album_name>", methods=["DELETE"])
+@api_albums_controller.route("/<album_name>", methods=["DELETE"])
 def delete_album(album_name: str) -> Response:
     """
     Delete an album.
@@ -170,7 +170,7 @@ def delete_album(album_name: str) -> Response:
     return Response(status=204)
 
 
-@api_albums_controller.route("<album_name>/<filename>", methods=["POST"])
+@api_albums_controller.route("/<album_name>/<filename>", methods=["POST"])
 def move_to_album(album_name: str, filename: str) -> Response:
     """
     Move an existing file from the "none" album to another album.
@@ -255,7 +255,7 @@ def upload_to_album(filename: str, date_taken: datetime, album_name: str) -> Res
     return Response(status=201)
 
 
-@api_albums_controller.route("<album_name>", methods=["GET"])
+@api_albums_controller.route("/<album_name>", methods=["GET"])
 def list_album(album_name: str) -> Response | list[MediaRecord]:
     """
     List the files in an album, sorted by last modified time.
@@ -291,7 +291,7 @@ def list_album(album_name: str) -> Response | list[MediaRecord]:
     return sorted(medias, reverse=True)
 
 
-@api_albums_controller.route("<album_name>/<filename>", methods=["DELETE"])
+@api_albums_controller.route("/<album_name>/<filename>", methods=["DELETE"])
 def remove_from_album(album_name: str, filename: str) -> Response:
     """
     Remove a photo from an album, putting it back in the "none" album.
@@ -333,7 +333,7 @@ def remove_from_album(album_name: str, filename: str) -> Response:
     return Response(status=204)
 
 
-@api_albums_controller.route("thumbnail/<album_name>", methods=["GET"])
+@api_albums_controller.route("/thumbnail/<album_name>", methods=["GET"])
 def get_album_thumbnail(album_name: str) -> Response:
     """
     Get the thumbnail for an album.

--- a/azurephotos/src/api/albums.py
+++ b/azurephotos/src/api/albums.py
@@ -114,7 +114,6 @@ def rename_album(album_name: str, new_name: str) -> Response:
     parameters = {"album_name": album_name}
     entities = table_client.query_entities(query_filter=query, parameters=parameters)
     for entity in entities:
-        print(entity["RowKey"])
         photo_copy = {
             "PartitionKey": new_name,
             "RowKey": entity["RowKey"],

--- a/azurephotos/src/api/albums.py
+++ b/azurephotos/src/api/albums.py
@@ -174,7 +174,7 @@ def delete_album(album_name: str) -> Response:
 def move_to_album(album_name: str, filename: str) -> Response:
     """
     Move an existing file from the "none" album to another album.
-    For uploading a new file to an album, use :func:`delete_album`
+    For uploading a new file to an album, use :func:`upload_to_album`.
 
     :param album_name: The name of the album to add the file to.
     :param filename: The filename to add to the album.

--- a/azurephotos/src/api/crud_controller.py
+++ b/azurephotos/src/api/crud_controller.py
@@ -12,7 +12,7 @@ from werkzeug.datastructures.file_storage import FileStorage
 
 import src.api.photos as photos
 import src.api.videos as videos
-from .media_cache import invalidates_media_cache
+from .media_cache import invalidate_media_cache
 
 from ..lib.storage_helper import get_container_sas
 from ..lib.models.media import MediaType
@@ -86,28 +86,12 @@ def fullsize(filename: str) -> Response:
 @crud_controller.route("/upload", methods=["POST"])
 def upload() -> Response:
     """
-    Upload a photo or video.
+    Upload a photo or video without specifying an album. The photo or video will be uploaded to the "none" album.
+    For uploading a photo or video to a specific album, use :func:`upload_to_album`.
     """
 
-    files = request.files.getlist("upload")
-    dates_taken = request.form.getlist("dateTaken")
+    return _upload_to_album(NONE_ALBUM_NAME)
 
-    if files is None or len(files) == 0:
-        raise ValueError("No files provided for upload")
-    if dates_taken is None or len(dates_taken) == 0:
-        raise ValueError("No dates provided for uploaded items")
-    if len(files) != len(dates_taken):
-        raise ValueError("Number of uploaded files and number of dates do not match")
-    
-    for file, date_string in zip(files, dates_taken):
-        try:
-            _ = _upload(file, date_string)
-        except ResourceExistsError as e:
-            return Response(str(e.message), status=409)
-
-    return Response(status=201)
-
-@invalidates_media_cache
 def _upload(file: FileStorage, date_string: str, album_name: str = NONE_ALBUM_NAME) -> Response:
     if file.filename is None:
         raise ValueError("File must have filename")
@@ -120,15 +104,17 @@ def _upload(file: FileStorage, date_string: str, album_name: str = NONE_ALBUM_NA
             uploaded_filename = videos.upload(file, date_taken)
         case _:
             raise ValueError(f"Unrecognized media type for {file.filename=}")
-        
+    
     upload_to_album_result = upload_directly_to_album(uploaded_filename, date_taken, album_name)
     if upload_to_album_result.status_code >= 400:
         return upload_to_album_result
-    else:
-        return Response(uploaded_filename, status=201)
+    
+    if album_name == NONE_ALBUM_NAME:
+        invalidate_media_cache()
+    
+    return Response(uploaded_filename, status=201)
 
 
-# No invalidate media cache needed here because we upload directly to an album
 @crud_controller.route("/upload/<album_name>", methods=["POST"])
 def upload_to_album(album_name: str) -> Response:
     """
@@ -140,7 +126,16 @@ def upload_to_album(album_name: str) -> Response:
 
     if album_name == NONE_ALBUM_NAME:
         return Response(f"Album name '{NONE_ALBUM_NAME}' is reserved and cannot be uploaded to directly", status=403)
+    
+    return _upload_to_album(album_name)
 
+def _upload_to_album(album_name: str) -> Response:
+    """
+    Helper for :func:`upload` and :func:`upload_to_album`.
+    Skips any checks for reserved album names since those are already handled in the calling functions.
+    Clients should not call this function directly, but rather use :func:`upload` or :func:`upload_to_album`.
+    """
+    
     files = request.files.getlist("upload")
     dates_taken = request.form.getlist("dateTaken")
 
@@ -166,7 +161,6 @@ def upload_to_album(album_name: str) -> Response:
     return Response(status=201)
 
 @crud_controller.route("/delete/<filename>", methods=["DELETE"])
-@invalidates_media_cache
 def delete(filename: str) -> Response:
     """
     Delete an entry from the storage account.
@@ -187,7 +181,9 @@ def delete(filename: str) -> Response:
         case _:
             raise ValueError(f"Unrecognized media type for {filename=}")
 
-    remove_from_all_albums(filename)
+    albums_affected = remove_from_all_albums(filename)
+    if NONE_ALBUM_NAME in albums_affected:
+        invalidate_media_cache()
 
     # Client JS code should remove image from view
     return Response(status=204)

--- a/azurephotos/src/api/crud_controller.py
+++ b/azurephotos/src/api/crud_controller.py
@@ -6,7 +6,7 @@ Will delegate to the proper controller per media.
 from azure.core.exceptions import ResourceExistsError
 from azure.identity import DefaultAzureCredential
 from datetime import datetime
-from flask import Blueprint, redirect, current_app, request
+from flask import Blueprint, redirect, current_app, request, jsonify
 from werkzeug.wrappers.response import Response
 from werkzeug.datastructures.file_storage import FileStorage
 
@@ -139,24 +139,35 @@ def _upload_to_album(album_name: str) -> Response:
     files = request.files.getlist("upload")
     dates_taken = request.form.getlist("dateTaken")
 
-    if files is None or len(files) == 0:
+    if not files:
         raise ValueError("No files provided for upload")
-    if dates_taken is None or len(dates_taken) == 0:
+    if not dates_taken:
         raise ValueError("No dates provided for uploaded items")
     if len(files) != len(dates_taken):
         raise ValueError("Number of uploaded files and number of dates do not match")
 
-    upload_failures =  list[str]()
-    try:
-        for file, date_string in zip(files, dates_taken):
+    # TODO: Consider also tracking successes and then giving back a 207 that the frontend could use to show which files failed and which succeeded.
+    upload_failures = list[dict[str, str | int]]()
+    for file, date_string in zip(files, dates_taken):
+        try:
             upload_result = _upload(file, date_string, album_name)
             if upload_result.status_code >= 400:
-                upload_failures.append(str(upload_result.response))
-    except ResourceExistsError as e:
-        return Response(str(e.message), status=409)
+                upload_failures.append({
+                    "filename": file.filename or "<unknown>",
+                    "status_code": upload_result.status_code,
+                    "message": upload_result.get_data(as_text=True)
+                })
+        except ResourceExistsError as e:
+            upload_failures.append({
+                "filename": file.filename or "<unknown>",
+                "status_code": 409,
+                "message": str(e)
+            })
 
     if upload_failures:
-        return Response(upload_failures, status=400)
+        response = jsonify(upload_failures)
+        response.status_code = 400
+        return response
 
     return Response(status=201)
 

--- a/azurephotos/src/api/crud_controller.py
+++ b/azurephotos/src/api/crud_controller.py
@@ -17,7 +17,11 @@ from .media_cache import invalidates_media_cache
 from ..lib.storage_helper import get_container_sas
 from ..lib.models.media import MediaType
 
-from .albums import remove_from_all_albums, add_to_album, _add_to_reserved_album, NONE_ALBUM_NAME
+from .albums import (
+    remove_from_all_albums,
+    upload_to_album as upload_directly_to_album,
+    NONE_ALBUM_NAME
+)
 
 crud_controller = Blueprint(
     "crud_controller",
@@ -104,7 +108,10 @@ def upload() -> Response:
     return Response(status=201)
 
 @invalidates_media_cache
-def _upload(file: FileStorage, date_string: str) -> str:    
+def _upload(file: FileStorage, date_string: str, album_name: str = NONE_ALBUM_NAME) -> Response:
+    if file.filename is None:
+        raise ValueError("File must have filename")
+    
     date_taken = datetime.fromisoformat(date_string.strip())
     match MediaType.from_file_extension(file.filename):
         case MediaType.PHOTO:
@@ -114,16 +121,21 @@ def _upload(file: FileStorage, date_string: str) -> str:
         case _:
             raise ValueError(f"Unrecognized media type for {file.filename=}")
         
-    _ = _add_to_reserved_album(uploaded_filename, date_taken)
-
-    return uploaded_filename
+    upload_to_album_result = upload_directly_to_album(uploaded_filename, date_taken, album_name)
+    if upload_to_album_result.status_code >= 400:
+        return upload_to_album_result
+    else:
+        return Response(uploaded_filename, status=201)
 
 
 # No invalidate media cache needed here because we upload directly to an album
 @crud_controller.route("/upload/<album_name>", methods=["POST"])
 def upload_to_album(album_name: str) -> Response:
     """
-    Upload photos or videos, and add it to an album.
+    Upload a file directly to an album.
+    For uploading a photo to the "none" album, use :func:`upload`.
+
+    :param album_name: Album name to add to
     """
 
     if album_name == NONE_ALBUM_NAME:
@@ -139,15 +151,17 @@ def upload_to_album(album_name: str) -> Response:
     if len(files) != len(dates_taken):
         raise ValueError("Number of uploaded files and number of dates do not match")
 
+    upload_failures =  list[str]()
     try:
         for file, date_string in zip(files, dates_taken):
-            uploaded_filename = _upload(file, date_string)
-            add_to_album_result = add_to_album(album_name, uploaded_filename)
-            if add_to_album_result.status_code >= 400:
-                # TODO: Should we instead aggregate results at the end?
-                return add_to_album_result
+            upload_result = _upload(file, date_string, album_name)
+            if upload_result.status_code >= 400:
+                upload_failures.append(str(upload_result.response))
     except ResourceExistsError as e:
         return Response(str(e.message), status=409)
+
+    if upload_failures:
+        return Response(upload_failures, status=400)
 
     return Response(status=201)
 

--- a/azurephotos/src/api/crud_controller.py
+++ b/azurephotos/src/api/crud_controller.py
@@ -4,7 +4,6 @@ Will delegate to the proper controller per media.
 """
 
 from azure.core.exceptions import ResourceExistsError
-from azure.identity import DefaultAzureCredential
 from datetime import datetime
 from flask import Blueprint, redirect, current_app, request, jsonify
 from werkzeug.wrappers.response import Response
@@ -49,14 +48,10 @@ def thumbnail(filename: str) -> Response:
         case _:
             raise ValueError(f"Unrecognized {media_type=} for {filename=}")
 
-    account_name: str = current_app.config["account_name"]
-    blob_account_url: str = f"https://{account_name}.blob.core.windows.net"
-    credential: DefaultAzureCredential = current_app.config["credential"]
-    thumbnails_container_name: str = current_app.config["thumbnails_container_name"]
+    blob_account_url: str = current_app.config["blob_account_url"]
+    thumbnails_container_name: str = "thumbnails"
 
-    thumbnails_container_sas: str = get_container_sas(
-        account_name, thumbnails_container_name, credential
-    )
+    thumbnails_container_sas: str = get_container_sas(thumbnails_container_name)
     response = redirect(
         f"{blob_account_url}/{thumbnails_container_name}/{filename}?{thumbnails_container_sas}"
     )

--- a/azurephotos/src/api/crud_controller.py
+++ b/azurephotos/src/api/crud_controller.py
@@ -3,6 +3,7 @@ Generic API endpoints for handling any media.
 Will delegate to the proper controller per media.
 """
 
+from azure.core.exceptions import ResourceExistsError
 from azure.identity import DefaultAzureCredential
 from datetime import datetime
 from flask import Blueprint, redirect, current_app, request
@@ -93,31 +94,29 @@ def upload() -> Response:
         raise ValueError("No dates provided for uploaded items")
     if len(files) != len(dates_taken):
         raise ValueError("Number of uploaded files and number of dates do not match")
-
-    _upload(*zip(files, dates_taken))
+    
+    for file, date_string in zip(files, dates_taken):
+        try:
+            _ = _upload(file, date_string)
+        except ResourceExistsError as e:
+            return Response(str(e.message), status=409)
 
     return Response(status=201)
 
 @invalidates_media_cache
-def _upload(*file_infos: tuple[FileStorage, str]) -> list[str]:
-    uploaded_filenames = list[str]()
-    for file, date_taken in file_infos:
-        uploaded_filename = None
-
-        media_type = MediaType.from_file_extension(file.filename)
-        match media_type:
-            case MediaType.PHOTO:
-                uploaded_filename = photos.upload((file, date_taken))
-            case MediaType.VIDEO:
-                uploaded_filename = videos.upload((file, date_taken))
-            case _:
-                # TODO: Should we pass here and continue uploading other files?
-                raise ValueError(f"Unrecognized media type for {file.filename=}")
+def _upload(file: FileStorage, date_string: str) -> str:    
+    date_taken = datetime.fromisoformat(date_string.strip())
+    match MediaType.from_file_extension(file.filename):
+        case MediaType.PHOTO:
+            uploaded_filename = photos.upload(file, date_taken)
+        case MediaType.VIDEO:
+            uploaded_filename = videos.upload(file, date_taken)
+        case _:
+            raise ValueError(f"Unrecognized media type for {file.filename=}")
         
-        uploaded_filenames.append(uploaded_filename)
-        _ = _add_to_reserved_album(uploaded_filename, datetime.fromisoformat(date_taken))
+    _ = _add_to_reserved_album(uploaded_filename, date_taken)
 
-    return uploaded_filenames
+    return uploaded_filename
 
 
 # No invalidate media cache needed here because we upload directly to an album
@@ -140,12 +139,15 @@ def upload_to_album(album_name: str) -> Response:
     if len(files) != len(dates_taken):
         raise ValueError("Number of uploaded files and number of dates do not match")
 
-    uploaded_filenames = _upload(*zip(files, dates_taken))
-    for uploaded_filename in uploaded_filenames:
-        add_to_album_result = add_to_album(album_name, uploaded_filename)
-        if add_to_album_result.status_code >= 400:
-            # TODO: Should we instead aggregate results at the end?
-            return add_to_album_result
+    try:
+        for file, date_string in zip(files, dates_taken):
+            uploaded_filename = _upload(file, date_string)
+            add_to_album_result = add_to_album(album_name, uploaded_filename)
+            if add_to_album_result.status_code >= 400:
+                # TODO: Should we instead aggregate results at the end?
+                return add_to_album_result
+    except ResourceExistsError as e:
+        return Response(str(e.message), status=409)
 
     return Response(status=201)
 

--- a/azurephotos/src/api/health.py
+++ b/azurephotos/src/api/health.py
@@ -5,7 +5,6 @@ API endpoints for managing health
 """
 
 from flask import Blueprint, Response, current_app
-from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient, LinearRetry
 
 api_health_controller = Blueprint(
@@ -23,13 +22,10 @@ def health() -> Response:
     If the app is running fine and can talk to storage, respond with HTTP 200.
     """
 
-    credential: DefaultAzureCredential = current_app.config["credential"]
-    account_name: str = current_app.config["account_name"]
-    blob_account_url: str = f"https://{account_name}.blob.core.windows.net"
+    blob_service_client: BlobServiceClient = current_app.config["blob_service_client"]
 
     try:
-        with BlobServiceClient(blob_account_url, credential, retry_policy=LinearRetry(retry_total=0)) as blob_client:
-            _ = blob_client.list_containers(results_per_page=1).next().name
+        blob_service_client.get_account_information(retry_policy=LinearRetry(retry_total=0))
         return Response("ok", status=200, content_type="text/plain")
     except Exception as e:
         return Response(str(e), status=503, content_type="text/plain")

--- a/azurephotos/src/api/media_cache.py
+++ b/azurephotos/src/api/media_cache.py
@@ -1,5 +1,3 @@
-from azure.identity import DefaultAzureCredential
-from flask import current_app
 from typing import Sequence
 
 from ..lib.models.media import MediaRecord
@@ -16,13 +14,8 @@ def all_media() -> Sequence[MediaRecord]:
     if media_cache is not None:
         return media_cache
     
-    account_name: str = current_app.config["account_name"]
-    table_name: str = current_app.config["albums_table_name"]
-    credential: DefaultAzureCredential = current_app.config["credential"]
 
-    media_cache = sorted(
-        non_album_file_names(account_name, table_name, credential),
-        reverse=True)
+    media_cache = sorted(non_album_file_names(), reverse=True)
     return media_cache
 
 def invalidate_media_cache() -> None:

--- a/azurephotos/src/api/media_cache.py
+++ b/azurephotos/src/api/media_cache.py
@@ -1,6 +1,5 @@
 from azure.identity import DefaultAzureCredential
 from flask import current_app
-from functools import wraps
 from typing import Sequence
 
 from ..lib.models.media import MediaRecord
@@ -13,10 +12,7 @@ def all_media() -> Sequence[MediaRecord]:
     global media_cache
 
     if media_cache is not None:
-        print("SERVED MEDIA FROM CACHE")
         return media_cache
-    
-    print("RECALCULATING MEDIA")
     
     account_name: str = current_app.config["account_name"]
     table_name: str = current_app.config["albums_table_name"]
@@ -27,13 +23,6 @@ def all_media() -> Sequence[MediaRecord]:
         reverse=True)
     return media_cache
 
-def invalidates_media_cache(func):
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        global media_cache
-        result = func(*args, **kwargs)
-        media_cache = None
-        
-        return result
-
-    return wrapper
+def invalidate_media_cache() -> None:
+    global media_cache
+    media_cache = None

--- a/azurephotos/src/api/media_cache.py
+++ b/azurephotos/src/api/media_cache.py
@@ -33,7 +33,7 @@ def invalidates_media_cache(func):
         global media_cache
         result = func(*args, **kwargs)
         media_cache = None
-        print("INVALIDATED MEDIA CACHE")
+        
         return result
 
     return wrapper

--- a/azurephotos/src/api/media_cache.py
+++ b/azurephotos/src/api/media_cache.py
@@ -4,8 +4,10 @@ from typing import Sequence
 
 from ..lib.models.media import MediaRecord
 
-# All existing photos and videos not in an album, sorted by last modified time
 media_cache: Sequence[MediaRecord] | None = None
+"""
+All existing photos and videos not in an album, sorted by last modified time
+"""
 
 def all_media() -> Sequence[MediaRecord]:
     from .albums import non_album_file_names

--- a/azurephotos/src/api/photos.py
+++ b/azurephotos/src/api/photos.py
@@ -4,6 +4,7 @@ API endpoints for handling individual photos.
 :author: William Boyles
 """
 
+from azure.core.exceptions import ResourceExistsError
 from azure.identity import DefaultAzureCredential
 from azure.storage.blob import ContainerClient, BlobProperties, ContentSettings
 from datetime import datetime
@@ -74,7 +75,7 @@ def delete_thumbnail(filename: str) -> None:
         thumbnails_container_client.delete_blob(filename)
 
 
-def upload(file_info: tuple[FileStorage, str]) -> str:
+def upload(file: FileStorage, date_taken: datetime) -> str:
     """
     Upload photos to blob storage.
 
@@ -88,9 +89,8 @@ def upload(file_info: tuple[FileStorage, str]) -> str:
     thumbnails_container_name: str = current_app.config["thumbnails_container_name"]
     credential: DefaultAzureCredential = current_app.config["credential"]
 
-    file, modified_date = file_info
     save_filename = secure_filename(str(file.filename))
-    metadata = {"lastModified": modified_date}  # ISO timestamp
+    metadata = {"lastModified": date_taken.isoformat()}
     with ContainerClient(
         blob_account_url, photos_container_name, credential
     ) as photos_container_client, ContainerClient(

--- a/azurephotos/src/api/photos.py
+++ b/azurephotos/src/api/photos.py
@@ -4,9 +4,11 @@ API endpoints for handling individual photos.
 :author: William Boyles
 """
 
-from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
-from azure.identity import DefaultAzureCredential
-from azure.storage.blob import ContainerClient, BlobProperties, ContentSettings
+from io import BytesIO
+
+from azure.core.exceptions import ResourceNotFoundError
+from azure.storage.blob import ContainerClient, ContentSettings
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from flask import redirect, current_app
 from werkzeug.utils import secure_filename
@@ -15,8 +17,6 @@ from werkzeug.datastructures.file_storage import FileStorage
 
 from ..lib.storage_helper import get_container_sas
 from ..lib.thumbnails import thumbnail as compute_thumbnail
-from ..lib.models.media import MediaRecord, MediaType
-
 
 def fullsize(filename: str) -> Response:
     """
@@ -26,14 +26,10 @@ def fullsize(filename: str) -> Response:
     :param filename: The name of the file.
     """
 
-    account_name: str = current_app.config["account_name"]
-    blob_account_url: str = f"https://{account_name}.blob.core.windows.net"
-    credential: DefaultAzureCredential = current_app.config["credential"]
-    photos_container_name: str = current_app.config["photos_container_name"]
+    blob_account_url: str = current_app.config["blob_account_url"]
+    photos_container_name: str = "photos"
 
-    photos_container_sas: str = get_container_sas(
-        account_name, photos_container_name, credential
-    )
+    photos_container_sas: str = get_container_sas(photos_container_name)
     return redirect(
         f"{blob_account_url}/{photos_container_name}/{filename}?{photos_container_sas}"
     )
@@ -46,16 +42,10 @@ def delete_fullsize(filename: str) -> None:
     :param filename: The name of the photo file
     """
 
-    account_name: str = current_app.config["account_name"]
-    blob_account_url: str = f"https://{account_name}.blob.core.windows.net"
-    photos_container_name: str = current_app.config["photos_container_name"]
-    credential: DefaultAzureCredential = current_app.config["credential"]
+    photos_container_client: ContainerClient = current_app.config["photos_container_client"]
 
     try:
-        with ContainerClient(
-            blob_account_url, photos_container_name, credential
-        ) as photos_container_client:
-            photos_container_client.delete_blob(filename)
+        photos_container_client.delete_blob(filename)
     except ResourceNotFoundError:
         # Blob already deleted
         pass
@@ -68,16 +58,10 @@ def delete_thumbnail(filename: str) -> None:
     :param filename: The name of the photo file
     """
 
-    account_name: str = current_app.config["account_name"]
-    blob_account_url: str = f"https://{account_name}.blob.core.windows.net"
-    thumbnails_container_name: str = current_app.config["thumbnails_container_name"]
-    credential: DefaultAzureCredential = current_app.config["credential"]
+    thumbnails_container_client: ContainerClient = current_app.config["thumbnails_container_client"]
 
     try:
-        with ContainerClient(
-            blob_account_url, thumbnails_container_name, credential
-        ) as thumbnails_container_client:
-            thumbnails_container_client.delete_blob(filename)
+        thumbnails_container_client.delete_blob(filename)
     except ResourceNotFoundError:
         # Blob already deleted
         pass
@@ -91,76 +75,42 @@ def upload(file: FileStorage, date_taken: datetime) -> str:
         ResourceExistsError when blob with filename already exists
     """
 
-    account_name: str = current_app.config["account_name"]
-    blob_account_url: str = f"https://{account_name}.blob.core.windows.net"
-    photos_container_name: str = current_app.config["photos_container_name"]
-    thumbnails_container_name: str = current_app.config["thumbnails_container_name"]
-    credential: DefaultAzureCredential = current_app.config["credential"]
+    photos_container_client: ContainerClient = current_app.config["photos_container_client"]
+    thumbnails_container_client: ContainerClient = current_app.config["thumbnails_container_client"]
 
     save_filename = secure_filename(str(file.filename))
     metadata = {"lastModified": date_taken.isoformat()}
-    with ContainerClient(
-        blob_account_url, photos_container_name, credential
-    ) as photos_container_client, ContainerClient(
-        blob_account_url, thumbnails_container_name, credential
-    ) as thumbnails_container_client:
-        _ = thumbnails_container_client.upload_blob(
+    data = file.stream.read()
+
+    def upload_thumbnail(client: ContainerClient) -> None:
+        thumbnail = compute_thumbnail(BytesIO(data))
+        client.upload_blob(
             name=save_filename,
-            data=compute_thumbnail(file.stream),
+            data=thumbnail,
             metadata=metadata,
             content_settings=ContentSettings(
                 cache_control="public, max-age=31536000, immutable"
-            ),
+            )
         )
 
-        if file.stream.seekable():
-            file.stream.seek(0)
-
-        _ = photos_container_client.upload_blob(
-            name=save_filename, data=file.stream, metadata=metadata
+    def upload_fullsize(client: ContainerClient) -> None:
+        client.upload_blob(
+            name=save_filename,
+            data=BytesIO(data),
+            length=len(data),
+            max_concurrency=4,
+            metadata=metadata
         )
 
+    photos_container_client: ContainerClient = current_app.config["photos_container_client"]
+    thumbnails_container_client: ContainerClient = current_app.config["thumbnails_container_client"]
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        thumbnail_future = executor.submit(upload_thumbnail, thumbnails_container_client)
+        fullsize_future = executor.submit(upload_fullsize, photos_container_client)
+
+        _ = thumbnail_future.result()
+        _ = fullsize_future.result()
         # TODO: Try to delete thumbnail blob if fullsize upload failed
 
     return save_filename
-
-
-def all_photos(
-    account_name: str, photos_container_name: str, credential: DefaultAzureCredential
-) -> list[MediaRecord]:
-    """
-    Get all photos stored in blob storage and their last modified time.
-    Photos are ordered by their last modified time.
-    """
-
-    # credential: DefaultAzureCredential = current_app.config["credential"]
-    # account_name = current_app.config["account_name"]
-    blob_account_url: str = f"https://{account_name}.blob.core.windows.net"
-    # photos_container_name: str = current_app.config["photos_container_name"]
-
-    with ContainerClient(
-        blob_account_url, photos_container_name, credential
-    ) as container_client:
-        blobs = list(container_client.list_blobs(include="metadata"))
-
-    def last_modified(blob_properties: BlobProperties) -> datetime:
-        if (
-            not blob_properties.metadata
-            or not isinstance(blob_properties.metadata, dict)
-            or not blob_properties.metadata.get("lastModified")
-        ):
-            return blob_properties.last_modified  # type: ignore
-
-        return datetime.fromisoformat(blob_properties.metadata["lastModified"])
-
-    return sorted(
-        (
-            MediaRecord(
-                last_modified=last_modified(blob),
-                filename=str(blob.name),
-                type=MediaType.PHOTO,
-            )
-            for blob in blobs
-        ),
-        reverse=True,
-    )

--- a/azurephotos/src/api/photos.py
+++ b/azurephotos/src/api/photos.py
@@ -75,9 +75,6 @@ def upload(file: FileStorage, date_taken: datetime) -> str:
         ResourceExistsError when blob with filename already exists
     """
 
-    photos_container_client: ContainerClient = current_app.config["photos_container_client"]
-    thumbnails_container_client: ContainerClient = current_app.config["thumbnails_container_client"]
-
     save_filename = secure_filename(str(file.filename))
     metadata = {"lastModified": date_taken.isoformat()}
     data = file.stream.read()

--- a/azurephotos/src/api/videos.py
+++ b/azurephotos/src/api/videos.py
@@ -78,7 +78,7 @@ def fullsize(filename: str) -> Response:
     )
 
 
-def upload(file_info: tuple[FileStorage, str]) -> str:
+def upload(file: FileStorage, date_taken: datetime) -> str:
     """
     Upload videos to blob storage.
 
@@ -92,9 +92,8 @@ def upload(file_info: tuple[FileStorage, str]) -> str:
     thumbnails_container_name: str = current_app.config["thumbnails_container_name"]
     credential: DefaultAzureCredential = current_app.config["credential"]
 
-    file, modified_date = file_info
     save_filename = secure_filename(str(file.filename))
-    metadata = {"lastModified": modified_date}  # ISO timestamp
+    metadata = {"lastModified": date_taken.isoformat()}
     with ContainerClient(
         blob_account_url, videos_container_name, credential
     ) as videos_container_client, ContainerClient(

--- a/azurephotos/src/api/videos.py
+++ b/azurephotos/src/api/videos.py
@@ -4,60 +4,21 @@ API endpoints for handling videos.
 :author: William Boyles
 """
 
-from azure.core.exceptions import ResourceNotFoundError
-from azure.identity import DefaultAzureCredential
-from azure.storage.blob import ContainerClient, BlobProperties, ContentSettings
+import os
+import shutil
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
+
+from azure.core.exceptions import ResourceNotFoundError
+from azure.storage.blob import ContainerClient, ContentSettings
 from flask import redirect, current_app
 from werkzeug.utils import secure_filename
 from werkzeug.wrappers.response import Response
 from werkzeug.datastructures.file_storage import FileStorage
 
 from ..lib.thumbnails import video_thumbnail as compute_thumbnail
-from ..lib.models.media import MediaRecord, MediaType
 from ..lib.storage_helper import get_container_sas
-
-
-def all_videos(
-    account_name: str, videos_container_name: str, credential: DefaultAzureCredential
-) -> list[MediaRecord]:
-    """
-    Get all vidoes stored in blob storage and their last modified time.
-    Videos are ordered by their last modified time.
-    """
-
-    # credential: DefaultAzureCredential = current_app.config["credential"]
-    # account_name = current_app.config["account_name"]
-    blob_account_url: str = f"https://{account_name}.blob.core.windows.net"
-    # videos_container_name: str = current_app.config["videos_container_name"]
-
-    with ContainerClient(
-        blob_account_url, videos_container_name, credential
-    ) as container_client:
-        blobs = list(container_client.list_blobs(include="metadata"))
-
-        def last_modified(blob_properties: BlobProperties) -> datetime:
-            if (
-                not blob_properties.metadata
-                or not isinstance(blob_properties.metadata, dict)
-                or not blob_properties.metadata.get("lastModified")
-            ):
-                return blob_properties.last_modified  # type: ignore
-
-            return datetime.fromisoformat(blob_properties.metadata["lastModified"])
-
-        return sorted(
-            (
-                MediaRecord(
-                    last_modified=last_modified(blob),
-                    filename=str(blob.name),
-                    type=MediaType.VIDEO,
-                )
-                for blob in blobs
-            ),
-            reverse=True,
-        )
-
 
 def fullsize(filename: str) -> Response:
     """
@@ -66,14 +27,10 @@ def fullsize(filename: str) -> Response:
     :param filename: The name of the file.
     """
 
-    account_name: str = current_app.config["account_name"]
-    blob_account_url: str = f"https://{account_name}.blob.core.windows.net"
-    credential: DefaultAzureCredential = current_app.config["credential"]
-    videos_container_name: str = current_app.config["videos_container_name"]
+    blob_account_url: str = current_app.config["blob_account_url"]
+    videos_container_name: str = "videos"
 
-    videos_container_sas = get_container_sas(
-        account_name, videos_container_name, credential
-    )
+    videos_container_sas = get_container_sas(videos_container_name)
     return redirect(
         f"{blob_account_url}/{videos_container_name}/{filename}?{videos_container_sas}"
     )
@@ -87,36 +44,52 @@ def upload(file: FileStorage, date_taken: datetime) -> str:
         ResourceExistsError when blob with filename already exists
     """
 
-    account_name: str = current_app.config["account_name"]
-    blob_account_url: str = f"https://{account_name}.blob.core.windows.net"
-    videos_container_name: str = current_app.config["videos_container_name"]
-    thumbnails_container_name: str = current_app.config["thumbnails_container_name"]
-    credential: DefaultAzureCredential = current_app.config["credential"]
+    videos_container_client: ContainerClient = current_app.config["videos_container_client"]
+    thumbnails_container_client: ContainerClient = current_app.config["thumbnails_container_client"]
 
     save_filename = secure_filename(str(file.filename))
     metadata = {"lastModified": date_taken.isoformat()}
-    with ContainerClient(
-        blob_account_url, videos_container_name, credential
-    ) as videos_container_client, ContainerClient(
-        blob_account_url, thumbnails_container_name, credential
-    ) as thumbnails_container_client:
-        _ = thumbnails_container_client.upload_blob(
-            name=f"{save_filename}.webp",
-            data=compute_thumbnail(file.stream),
-            metadata=metadata,
-            content_settings=ContentSettings(
-                cache_control="public, max-age=31536000, immutable"
-            ),
-        )
 
-        if file.stream.seekable():
-            file.stream.seek(0)
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".video") as temp_file:
+        shutil.copyfileobj(file.stream, temp_file)   
+        temp_file.flush()
+        temp_path = temp_file.name       
+    file_size = os.path.getsize(temp_path)                                  
 
-        _ = videos_container_client.upload_blob(
-            name=save_filename, data=file.stream, metadata=metadata
-        )
+    try:
+        def upload_thumbnail(client: ContainerClient) -> None:
+            thumbnail_bytes = compute_thumbnail(temp_path)
+            _ = client.upload_blob(
+                name=f"{save_filename}.webp",
+                data=thumbnail_bytes,
+                metadata=metadata,
+                content_settings=ContentSettings(
+                    cache_control="public, max-age=31536000, immutable"
+                ),
+            )
 
-        # TODO: Try to delete thumbnail blob if fullsize upload failed
+        def upload_fullsize(client: ContainerClient) -> None:
+            with open(temp_path, "rb") as full:
+                _ = client.upload_blob(
+                    name=save_filename,
+                    data=full,
+                    length=file_size,
+                    max_concurrency=4,
+                    metadata=metadata
+                )
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            thumbnails_future = executor.submit(upload_thumbnail, thumbnails_container_client)
+            fullsize_future = executor.submit(upload_fullsize, videos_container_client)
+
+            # TODO: Try to delete thumbnail blob if fullsize upload failed
+            thumbnails_future.result()
+            fullsize_future.result()
+    finally:
+        try:
+            os.remove(temp_path)
+        except OSError:
+            pass
 
     return save_filename
 
@@ -128,16 +101,10 @@ def delete_fullsize(filename: str) -> None:
     :param filename: The name of the video file
     """
 
-    account_name: str = current_app.config["account_name"]
-    blob_account_url: str = f"https://{account_name}.blob.core.windows.net"
-    videos_container_name: str = current_app.config["videos_container_name"]
-    credential: DefaultAzureCredential = current_app.config["credential"]
+    videos_container_client: ContainerClient = current_app.config["videos_container_client"]
 
     try:
-        with ContainerClient(
-            blob_account_url, videos_container_name, credential
-        ) as container_client:
-            container_client.delete_blob(filename)
+        videos_container_client.delete_blob(filename)
     except ResourceNotFoundError:
         # Blob already deleted
         pass
@@ -149,19 +116,12 @@ def delete_thumbnail(filename: str) -> None:
 
     :param filename: The name of the photo file
     """
-
-    account_name: str = current_app.config["account_name"]
-    blob_account_url: str = f"https://{account_name}.blob.core.windows.net"
-    thumbnails_container_name: str = current_app.config["thumbnails_container_name"]
-    credential: DefaultAzureCredential = current_app.config["credential"]
+    thumbnails_container_client: ContainerClient = current_app.config["thumbnails_container_client"]
 
     thumbnail_filename = filename + ".webp"
 
     try:
-        with ContainerClient(
-            blob_account_url, thumbnails_container_name, credential
-        ) as thumbnails_container_client:
-            thumbnails_container_client.delete_blob(thumbnail_filename)
+        thumbnails_container_client.delete_blob(thumbnail_filename)
     except ResourceNotFoundError:
         # Blob already deleted
         pass

--- a/azurephotos/src/lib/models/media.py
+++ b/azurephotos/src/lib/models/media.py
@@ -40,7 +40,7 @@ class MediaType(str, Enum):
     VIDEO = "video"
 
     @classmethod
-    def from_file_extension(cls, filename: str | None) -> MediaType | None:
+    def from_file_extension(cls, filename: str | None) -> 'MediaType | None':
         """
         Determine the :class:`MediaType` from the incoming file's extension.
 
@@ -74,7 +74,7 @@ class MediaRecord:
     type: MediaType = field(compare=False)
 
     @classmethod
-    def from_filename(cls, last_modified: datetime, filename: str) -> MediaRecord | None:
+    def from_filename(cls, last_modified: datetime, filename: str) -> 'MediaRecord | None':
         media_type = MediaType.from_file_extension(filename)
         if media_type is None:
             return None

--- a/azurephotos/src/lib/models/media.py
+++ b/azurephotos/src/lib/models/media.py
@@ -43,6 +43,8 @@ class MediaType(str, Enum):
     def from_file_extension(cls, filename: str | None) -> MediaType | None:
         """
         Determine the :class:`MediaType` from the incoming file's extension.
+
+        :param filename: file name with extension
         """
         
         if filename is None:

--- a/azurephotos/src/lib/storage_helper.py
+++ b/azurephotos/src/lib/storage_helper.py
@@ -1,54 +1,29 @@
-from azure.identity import DefaultAzureCredential
 from datetime import datetime, timedelta, timezone
+from flask import current_app
 from azure.storage.blob import (
     ContainerSasPermissions,
     generate_container_sas,
     BlobServiceClient,
 )
-from azure.data.tables import TableServiceClient, TableClient
 from .refresher import refreshed
 
 @refreshed(every=timedelta(minutes=15))
-def get_container_sas(
-    account_name: str, container_name: str, credential: DefaultAzureCredential
-) -> str:
-    blob_account_url = f"https://{account_name}.blob.core.windows.net"
-
+def get_container_sas(container_name: str) -> str:
     now = datetime.now(timezone.utc)
     sas_start = now - timedelta(minutes=1)
     sas_end = now + timedelta(minutes=30)
 
-    with BlobServiceClient(blob_account_url, credential) as bsc:
-        user_delegation_key = bsc.get_user_delegation_key(
-            key_start_time=sas_start, key_expiry_time=sas_end
-        )
-
-        container_sas: str = generate_container_sas(
-            account_name=account_name,
-            container_name=container_name,
-            user_delegation_key=user_delegation_key,
-            permission=ContainerSasPermissions(read=True),
-            start=sas_start,
-            expiry=sas_end,
-        )
-
-    return container_sas
-
-
-def get_table_client(
-    account_name: str, table_name: str, credential: DefaultAzureCredential
-) -> TableClient:
-    """
-    Built a TableClient for an account and
-
-    :param account_name: Storage account name
-    :param table_name: Name of table in storage account
-    :param credential: Credential for storage account
-    """
-
-    table_service_client = TableServiceClient(
-        endpoint=f"https://{account_name}.table.core.windows.net", credential=credential
+    bsc: BlobServiceClient = current_app.config["blob_service_client"]
+    user_delegation_key = bsc.get_user_delegation_key(
+        key_start_time=sas_start,
+        key_expiry_time=sas_end
     )
-    table_client = table_service_client.get_table_client(table_name)
 
-    return table_client
+    return generate_container_sas(
+        account_name=str(bsc.account_name),
+        container_name=container_name,
+        user_delegation_key=user_delegation_key,
+        permission=ContainerSasPermissions(read=True),
+        start=sas_start,
+        expiry=sas_end,
+    )

--- a/azurephotos/src/lib/storage_helper.py
+++ b/azurephotos/src/lib/storage_helper.py
@@ -41,9 +41,9 @@ def get_table_client(
     """
     Built a TableClient for an account and
 
-    - account_name: Storage account name
-    - table_name: Name of table in storage account
-    - credential: Credential for storage account
+    :param account_name: Storage account name
+    :param table_name: Name of table in storage account
+    :param credential: Credential for storage account
     """
 
     table_service_client = TableServiceClient(

--- a/azurephotos/src/lib/thumbnails.py
+++ b/azurephotos/src/lib/thumbnails.py
@@ -104,7 +104,7 @@ def thumbnail(photo_bytes: IO[bytes]) -> BytesIO:
     except DecompressionBombError:
         raise ValueError("Image is too large")
 
-def video_thumbnail(video_bytes: IO[bytes]) -> bytes:
+def video_thumbnail(video_path: str) -> bytes:
     """
     Create a compressed thumbnail of a video.
 
@@ -112,7 +112,7 @@ def video_thumbnail(video_bytes: IO[bytes]) -> bytes:
     - Takes thumbnail from first second of video, falling back to 0 seconds if video is shorter than 1 second
     - Appends a play button icon to the top-left of the thumbnail to differentiate it from photo thumbnails
 
-    NOTE: photo_bytes stream may be consumed/advanced by this method. 
+    NOTE: Caller owns :obj:`video_path` and is responsible for cleaning it up after this method returns
     """
     
     # find ffmpeg
@@ -125,12 +125,6 @@ def video_thumbnail(video_bytes: IO[bytes]) -> bytes:
     if not os.path.exists(video_icon_path):
         raise Exception("Cannot find video icon")
 
-    # Copy bytes to temporary file
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".mp4") as temp_video:
-        shutil.copyfileobj(video_bytes, temp_video)
-        temp_video.flush()
-        temp_video_path = temp_video.name
-
     # Use ffmpeg to compute thumbnail
     def run_ffmpeg(seek_seconds: int = 1) -> bytes:
         cmd = [
@@ -138,7 +132,7 @@ def video_thumbnail(video_bytes: IO[bytes]) -> bytes:
             "-hide_banner",
             "-loglevel", "error",
             "-ss", str(seek_seconds),
-            "-i", temp_video_path,
+            "-i", video_path,
             "-i", video_icon_path,
             "-frames:v", "1",
             "-filter_complex",
@@ -159,27 +153,18 @@ def video_thumbnail(video_bytes: IO[bytes]) -> bytes:
                 stderr = subprocess.PIPE,
                 check = True
             )
-            
-            process_stdout = process.stdout
-            if process_stdout is None or len(process_stdout) == 0:
-                if seek_seconds != 0: # fallback to seeking to 0 seconds
-                    return run_ffmpeg(seek_seconds=0)
-                else:
-                    raise RuntimeError("No output from ffmpeg process")
-        
-            return process_stdout
         except subprocess.CalledProcessError as e:
             # TODO: Should we create a default thumbnail? Maybe this can be done in /thumbnail route?
             raise RuntimeError(
                 f"ffmpeg failed:\n{e.stderr.decode(errors='ignore')}"
             ) from e
 
-    try:
-        ffmpeg_results = run_ffmpeg()
-    finally:
-        os.remove(temp_video_path)
+        if not process.stdout:
+            if seek_seconds != 0: # fallback to seeking to 0 seconds
+                return run_ffmpeg(seek_seconds=0)
+            else:
+                raise RuntimeError("No output from ffmpeg process")
     
-    if ffmpeg_results is None or len(ffmpeg_results) == 0:
-        raise RuntimeError("No output from ffmpeg process")
+        return process.stdout
 
-    return ffmpeg_results
+    return run_ffmpeg()

--- a/azurephotos/src/view/view.py
+++ b/azurephotos/src/view/view.py
@@ -43,7 +43,6 @@ def main() -> str:
         media = all_media_future.result()
         album_names = list_albums_future.result()
     
-    print("SERVING PAGE")
     return render_template("photos.html", medias=media, albums=album_names)
 
 @albums_view_controller.route("/<album_name>", methods=["GET"])

--- a/azurephotos/static/index.js
+++ b/azurephotos/static/index.js
@@ -91,8 +91,9 @@ function uploadWithConcurrency(files, path, concurrency) {
 
                 updateProgressBar();
                 resolve();
-            }
+            };
             xhr.onerror = () => {
+                failureCount++;
                 errors.push({
                     file: file.name,
                     status: "network error"
@@ -100,7 +101,7 @@ function uploadWithConcurrency(files, path, concurrency) {
 
                 updateProgressBar();
                 resolve();
-            }
+            };
 
             xhr.send(formData);
         });
@@ -118,6 +119,96 @@ function uploadWithConcurrency(files, path, concurrency) {
                 active++;
 
                 uploadSingle(file).then(() => {
+                    active--;
+                    next();
+                });
+            }
+        }
+
+        successCount = 0;
+        updateProgressBar();
+
+        next();
+    });
+}
+
+function deleteWithConcurrency(filenames, path, concurrency) {
+    filenames = Array.from(filenames);
+    let index = 0;
+    let active = 0;
+
+    const totalFiles = filenames.length;
+    let successCount = 0;
+    let failureCount = 0;
+    const errors = [];
+
+    function updateProgressBar() {
+        const successPercent = Math.round((successCount / totalFiles) * 100);
+        const failurePercent = Math.round((failureCount / totalFiles) * 100);
+
+        $("#successProgress")
+            .css("width", successPercent + "%")
+            .attr("aria-valuenow", successPercent)
+            .text(`${successCount} / ${totalFiles}`)
+        $("#failureProgress")
+            .css("width", failurePercent + "%")
+            .attr("aria-valuenow", failurePercent)
+            .text(`${failureCount} / ${totalFiles}`)
+    }
+
+    function deleteSingle(filename) {
+        return new Promise((resolve) => {
+            const xhr = new XMLHttpRequest();
+            const pathWithFile = `${path}/${filename}`
+            xhr.open("DELETE", pathWithFile);
+
+            xhr.onload = () => {
+                if (xhr.status >= 200 && xhr.status < 300) {
+                    successCount++;
+
+                    const thumbnailQuery = `[src="/thumbnail/${filename}"]`;
+                    const deletedThumbnail = document.querySelector(thumbnailQuery);
+                    if (deletedThumbnail) {
+                        deletedThumbnail.closest(".col").remove();
+                    }
+                } else {
+                    failureCount++;
+                    errors.push({
+                        file: filename,
+                        status: xhr.status
+                    });
+                }
+
+                updateProgressBar();
+                resolve();
+            };
+            xhr.onerror = () => {
+                failureCount++;
+                errors.push({
+                    file: filename,
+                    status: "network error"
+                });
+
+                updateProgressBar();
+                resolve();
+            };
+
+            xhr.send();
+        })
+    }
+
+    return new Promise((resolve) => {
+        function next() {
+            if (index === filenames.length && active === 0) {
+                resolve({ successCount, totalFiles, errors });
+                return;
+            }
+
+            while(active < concurrency && index < filenames.length) {
+                const filename = filenames[index++];
+                active++;
+
+                deleteSingle(filename).then(() => {
                     active--;
                     next();
                 });
@@ -214,7 +305,7 @@ $(document).ready(() => {
     $("#uploadForm").on('submit', function (event) {
         event.preventDefault();
 
-        const isAlbum = typeof (album) !== "undefined";
+        const isAlbum = (typeof album) !== "undefined";
         const path = isAlbum ? `/upload/${album}` : `/upload`;
 
         const input = document.getElementById("formFileLg");
@@ -239,8 +330,8 @@ $(document).ready(() => {
 
         $("#formFileLg").prop("disabled", true);
         $("#submitUpload").prop("disabled", true);
-        $("#uploadProgress .progress-bar").addClass("progress-bar-animated");
-        $("#uploadProgress").show();
+        $("#operationProgress .progress-bar").addClass("progress-bar-animated");
+        $("#operationProgress").show();
 
         uploadWithConcurrency(validFiles, path, 2)
             .then(({ successCount, totalFiles, errors }) => {
@@ -255,16 +346,17 @@ $(document).ready(() => {
             .finally(() => {
                 $("#formFileLg").prop("disabled", false);
                 $("#submitUpload").prop("disabled", false);
-                $("#uploadProgress .progress-bar").removeClass("progress-bar-animated");
+                $("#operationProgress .progress-bar").removeClass("progress-bar-animated");
                 setTimeout(() => { 
-                    $("#uploadProgress").hide(); 
+                    $("#operationProgress").hide();
                 }, 500);
             });
     });
 
-    // Delete photo or video
+    // Delete photos and videos
     $(".photo-action.delete-btn").click(function (event) {
         const isAlbum = (typeof album) !== "undefined";
+        const basePath = isAlbum ? `/api/albums/${album}` : `/delete`;
 
         // If we clicked the delete button on an unchecked item, add it to selected items
         const selected = event.currentTarget.dataset.selected;
@@ -277,25 +369,25 @@ $(document).ready(() => {
             return;
         }
 
-        selectedItems.forEach(selectedItem => {
-            const deleteUrl = isAlbum ? `/api/albums/${album}/${selectedItem}` : `/delete/${selectedItem}`;
-            fetch(deleteUrl, { method: "DELETE" })
-                .then(response => {
-                    if (response.ok) {
-                        const selectedItemQuery = `[src="/thumbnail/${selectedItem}"]`;
-                        const deletedThumbnail = document.querySelector(selectedItemQuery);
-                        if (deletedThumbnail) {
-                            deletedThumbnail.closest(".col").remove();
-                        }
-                        selectedItems.delete(selectedItem)
-                    } else {
-                        console.log(response);
-                    }
-                })
-                .catch(error => {
-                    console.log(error);
-                });
-        });
+        $("#operationProgress .progress-bar").addClass("progress-bar-animated");
+        $("#operationProgress").show();
+
+        deleteWithConcurrency(selectedItems, basePath, 4)
+            .then(({ successCount, totalFiles, errors }) => {
+                if (errors.length > 0) {
+                    console.warn("Some deletes failed:", errors);
+                    alert(`${successCount}/${totalFiles} deletes succeeded`);
+                    return;
+                }
+
+                selectedItems.clear();
+            })
+            .finally(() => {
+                $("#operationProgress .progress-bar").removeClass("progress-bar-animated");
+                setTimeout(() => { 
+                    $("#operationProgress").hide(); 
+                }, 500);
+            });
     });
 
     // Place photo or video in album

--- a/azurephotos/static/index.js
+++ b/azurephotos/static/index.js
@@ -189,7 +189,7 @@ function uploadFile(file, path) {
  * @returns {Promise<void>}
  */
 function deleteFile(file, path) {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
         const xhr = new XMLHttpRequest();
         xhr.open("DELETE", path);
 
@@ -222,7 +222,7 @@ function deleteFile(file, path) {
  * @returns {Promise<void>}
  */
 function moveToAlbum(file, path) {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
         const xhr = new XMLHttpRequest();
         xhr.open("POST", path);
 

--- a/azurephotos/static/index.js
+++ b/azurephotos/static/index.js
@@ -77,7 +77,7 @@ function isVideo(filename) {
  * @returns {Promise<{
  *  successCount: number;
  *  failureCount: number;
- *  totalItems: number;
+ *  totalCount: number;
  *  errors: Array<{
  *      item: T;
  *      error: unknown
@@ -369,10 +369,10 @@ $(document).ready(() => {
             (file) => uploadFile(file, path),
             2
         )
-            .then(({ successCount, failureCount, totalItems, errors }) => {
+            .then(({ successCount, failureCount, totalCount, errors }) => {
                 if (failureCount > 0) {
                     console.warn("Some uploads failed:", errors);
-                    alert(`${successCount}/${totalItems} uploads succeeded`);
+                    alert(`${successCount}/${totalCount} uploads succeeded`);
                     return;
                 }
 
@@ -412,10 +412,10 @@ $(document).ready(() => {
             (file) => deleteFile(file, `${basePath}/${file}`),
             4
         )
-            .then(({ successCount, failureCount, totalItems, errors }) => {
+            .then(({ successCount, failureCount, totalCount, errors }) => {
                 if (failureCount) {
                     console.warn("Some deletes failed:", errors);
-                    alert(`${successCount}/${totalItems} deletes succeeded`);
+                    alert(`${successCount}/${totalCount} deletes succeeded`);
                     return;
                 }
 
@@ -457,10 +457,10 @@ $(document).ready(() => {
                 (file) => moveToAlbum(file, `${basePath}/${file}`),
                 4
             )
-                .then(({ successCount, failureCount, totalItems, errors }) => {
+                .then(({ successCount, failureCount, totalCount, errors }) => {
                     if (failureCount) {
                         console.warn("Some moves failed:", errors);
-                        alert(`${successCount}/${totalItems} moves succeeded`);
+                        alert(`${successCount}/${totalCount} moves succeeded`);
                         return;
                     }
                     

--- a/azurephotos/static/index.js
+++ b/azurephotos/static/index.js
@@ -1,4 +1,7 @@
-// Should match src.lib.models.media.PHOTO_EXTENSIONS
+/**
+ * Collection of file extensions representing supported photo types.
+ * Should match src.lib.models.media.PHOTO_EXTENSIONS
+ */
 const PHOTO_EXTENSIONS = new Set([
     ".jpg", ".jpeg", ".jpe", ".jfif",
     ".png",
@@ -10,7 +13,10 @@ const PHOTO_EXTENSIONS = new Set([
     ".heic", ".heif",
 ]);
 
-// Should match src.lib.models.media.VIDEO_EXTENSIONS
+/**
+ * Collection of file extensions representing supported video types.
+ * Should match src.lib.models.media.VIDEO_EXTENSIONS
+ */
 const VIDEO_EXTENSIONS = new Set([
     ".mp4",
     ".mov",
@@ -24,6 +30,12 @@ const VIDEO_EXTENSIONS = new Set([
     ".m2ts",
 ]);
 
+/**
+ * Get the extension from a file name.
+ * @example getExtension("video.mp4") === ".mp4"
+ * @param {string} filename File name with extension
+ * @returns {string?}
+ */
 function getExtension(filename) {
     if (typeof filename !== 'string') {
         return null;
@@ -34,191 +46,171 @@ function getExtension(filename) {
     return extension;
 }
 
+/**
+ * Determine if a filename is a supported photo type.
+ * @param {string} filename File name with extension
+ * @returns {boolean}
+ */
 function isPhoto(filename) {
     const extension = getExtension(filename);
     return PHOTO_EXTENSIONS.has(extension);
 }
 
+/**
+ * Determine if a filename is a supported video type.
+ * @param {string} filename File name with extension
+ * @returns {boolean}
+ */
 function isVideo(filename) {
     const extension = getExtension(filename);
     return VIDEO_EXTENSIONS.has(extension);
 }
 
-function uploadWithConcurrency(files, path, concurrency) {
+/**
+ * Perform an action on a collection of items
+ * Update the progress bar as actions are successful or failed
+ * Limit the number of concurrent actions run at once.
+ * 
+ * @param {Iterable<T> | ArrayLike<T>} items Collection of items to act upon
+ * @param {(item: T) => Promise<void>} action Action to perform on each item
+ * @param {number} concurrency Max concurrency limit
+ * @returns {Promise<{
+ *  successCount: number;
+ *  failureCount: number;
+ *  totalItems: number;
+ *  errors: Array<{
+ *      item: T;
+ *      error: unknown
+ *  }>;
+ * }>}
+ */
+function doWithProgressBarWithConcurrency(items, action, concurrency) {
+    items = Array.from(items);
+    const totalCount = items.length;
+
     let index = 0;
     let active = 0;
-
-    const totalFiles = files.length;
     let successCount = 0;
     let failureCount = 0;
     const errors = [];
 
     function updateProgressBar() {
-        const successPercent = Math.round((successCount / totalFiles) * 100);
-        const failurePercent = Math.round((failureCount / totalFiles) * 100);
+        const successPercent = Math.round((successCount / totalCount) * 100);
+        const failurePercent = Math.round((failureCount / totalCount) * 100);
 
         $("#successProgress")
             .css("width", successPercent + "%")
             .attr("aria-valuenow", successPercent)
-            .text(`${successCount} / ${totalFiles}`)
+            .text(`${successCount} / ${totalCount}`)
         $("#failureProgress")
             .css("width", failurePercent + "%")
             .attr("aria-valuenow", failurePercent)
-            .text(`${failureCount} / ${totalFiles}`)
-    }
-
-    function uploadSingle(file) {
-        return new Promise((resolve) => {
-            const formData = new FormData();
-            formData.append("upload", file);
-
-            const dateTaken = new Date(file.lastModified);
-            formData.append("dateTaken", dateTaken.toISOString());
-
-            const xhr = new XMLHttpRequest();
-            xhr.open("POST", path);
-
-            xhr.onload = () => {
-                if (xhr.status >= 200 && xhr.status < 300) {
-                    successCount++;
-                } else {
-                    failureCount++;
-                    errors.push({
-                        file: file.name,
-                        status: xhr.status
-                    });
-                }
-
-                updateProgressBar();
-                resolve();
-            };
-            xhr.onerror = () => {
-                failureCount++;
-                errors.push({
-                    file: file.name,
-                    status: "network error"
-                });
-
-                updateProgressBar();
-                resolve();
-            };
-
-            xhr.send(formData);
-        });
+            .text(`${failureCount} / ${totalCount}`)
     }
 
     return new Promise((resolve) => {
         function next() {
-            if (index === files.length && active === 0) {
-                resolve({ successCount, totalFiles, errors });
+            if (index === totalCount && active === 0) {
+                resolve({
+                    successCount,
+                    failureCount,
+                    totalCount,
+                    errors
+                });
                 return;
             }
 
-            while (active < concurrency && index < files.length) {
-                const file = files[index++];
+            while (active < concurrency && index < totalCount) {
+                const item = items[index++];
                 active++;
 
-                uploadSingle(file).then(() => {
-                    active--;
-                    next();
-                });
+                action(item)
+                    .then(() => {
+                        successCount++;
+                    })
+                    .catch((error) => {
+                        failureCount++;
+                        errors.push({
+                            item,
+                            error
+                        });
+                    })
+                    .finally(() =>{
+                        active--;
+                        updateProgressBar();
+                        next();
+                    })
             }
         }
 
-        successCount = 0;
         updateProgressBar();
-
         next();
+    })
+}
+
+/**
+ * Upload a single file by HTTP POSTing to a particular path.
+ * 
+ * @param {File} file File to upload
+ * @param {string} path API path to send request
+ * @returns {Promise<void>}
+ */
+function uploadFile(file, path) {
+    return new Promise((resolve, reject) => {
+        const formData = new FormData();
+        formData.append("upload", file);
+
+        const lastModified = new Date(file.lastModified);
+        formData.append("dateTaken", dateTaken.toISOString());
+
+        const xhr = new XMLHttpRequest();
+        xhr.open("POST", path);
+
+        xhr.onload = () => {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                resolve();
+            } else {
+                reject(xhr.status);
+            }
+        };
+        xhr.onerror = () => {
+            reject("network error");
+        }
+
+        xhr.send(formData);
     });
 }
 
-function deleteWithConcurrency(filenames, path, concurrency) {
-    filenames = Array.from(filenames);
-    let index = 0;
-    let active = 0;
+/**
+ * Delete a single file by HTTP DELETEing to a particular path.
+ * 
+ * @param {string} file File name with extension
+ * @param {string} basePath API path to send request
+ * @returns {Promise<void>}
+ */
+function deleteFile(file, path) {
+    return new Promise((resolve) => {
+        const xhr = new XMLHttpRequest();
+        xhr.open("DELETE", path);
 
-    const totalFiles = filenames.length;
-    let successCount = 0;
-    let failureCount = 0;
-    const errors = [];
-
-    function updateProgressBar() {
-        const successPercent = Math.round((successCount / totalFiles) * 100);
-        const failurePercent = Math.round((failureCount / totalFiles) * 100);
-
-        $("#successProgress")
-            .css("width", successPercent + "%")
-            .attr("aria-valuenow", successPercent)
-            .text(`${successCount} / ${totalFiles}`)
-        $("#failureProgress")
-            .css("width", failurePercent + "%")
-            .attr("aria-valuenow", failurePercent)
-            .text(`${failureCount} / ${totalFiles}`)
-    }
-
-    function deleteSingle(filename) {
-        return new Promise((resolve) => {
-            const xhr = new XMLHttpRequest();
-            const pathWithFile = `${path}/${filename}`
-            xhr.open("DELETE", pathWithFile);
-
-            xhr.onload = () => {
-                if (xhr.status >= 200 && xhr.status < 300) {
-                    successCount++;
-
-                    const thumbnailQuery = `[src="/thumbnail/${filename}"]`;
-                    const deletedThumbnail = document.querySelector(thumbnailQuery);
-                    if (deletedThumbnail) {
-                        deletedThumbnail.closest(".col").remove();
-                    }
-                } else {
-                    failureCount++;
-                    errors.push({
-                        file: filename,
-                        status: xhr.status
-                    });
+        xhr.onload = () => {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                const thumbnailQuery = `[src="/thumbnail/${file}"]`;
+                const deletedThumbnail = document.querySelector(thumbnailQuery);
+                if (deletedThumbnail) {
+                    deletedThumbnail.closest(".col").remove();
                 }
 
-                updateProgressBar();
                 resolve();
-            };
-            xhr.onerror = () => {
-                failureCount++;
-                errors.push({
-                    file: filename,
-                    status: "network error"
-                });
-
-                updateProgressBar();
-                resolve();
-            };
-
-            xhr.send();
-        })
-    }
-
-    return new Promise((resolve) => {
-        function next() {
-            if (index === filenames.length && active === 0) {
-                resolve({ successCount, totalFiles, errors });
-                return;
+            } else {
+                reject(xhr.status);
             }
+        };
+        xhr.onerror = () => {
+            reject("network error");
+        };
 
-            while(active < concurrency && index < filenames.length) {
-                const filename = filenames[index++];
-                active++;
-
-                deleteSingle(filename).then(() => {
-                    active--;
-                    next();
-                });
-            }
-        }
-
-        successCount = 0;
-        updateProgressBar();
-
-        next();
+        xhr.send();
     });
 }
 
@@ -333,9 +325,13 @@ $(document).ready(() => {
         $("#operationProgress .progress-bar").addClass("progress-bar-animated");
         $("#operationProgress").show();
 
-        uploadWithConcurrency(validFiles, path, 2)
-            .then(({ successCount, totalFiles, errors }) => {
-                if (errors.length > 0) {
+        doWithProgressBarWithConcurrency(
+            validFiles,
+            (file) => uploadFile(file, path),
+            2
+        )
+            .then(({ successCount, failureCount, totalFiles, errors }) => {
+                if (failureCount > 0) {
                     console.warn("Some uploads failed:", errors);
                     alert(`${successCount}/${totalFiles} uploads succeeded`);
                     return;
@@ -372,9 +368,13 @@ $(document).ready(() => {
         $("#operationProgress .progress-bar").addClass("progress-bar-animated");
         $("#operationProgress").show();
 
-        deleteWithConcurrency(selectedItems, basePath, 4)
-            .then(({ successCount, totalFiles, errors }) => {
-                if (errors.length > 0) {
+        doWithProgressBarWithConcurrency(
+            selectedItems,
+            (file) => deleteFile(file, `${basePath}/${file}`),
+            4
+        )
+            .then(({ successCount, failureCount, totalFiles, errors }) => {
+                if (failureCount) {
                     console.warn("Some deletes failed:", errors);
                     alert(`${successCount}/${totalFiles} deletes succeeded`);
                     return;

--- a/azurephotos/static/index.js
+++ b/azurephotos/static/index.js
@@ -161,7 +161,7 @@ function uploadFile(file, path) {
         formData.append("upload", file);
 
         const lastModified = new Date(file.lastModified);
-        formData.append("dateTaken", dateTaken.toISOString());
+        formData.append("dateTaken", lastModified.toISOString());
 
         const xhr = new XMLHttpRequest();
         xhr.open("POST", path);
@@ -185,7 +185,7 @@ function uploadFile(file, path) {
  * Delete a single file by HTTP DELETEing to a particular path.
  * 
  * @param {string} file File name with extension
- * @param {string} basePath API path to send request
+ * @param {string} path API path to send request
  * @returns {Promise<void>}
  */
 function deleteFile(file, path) {
@@ -214,12 +214,51 @@ function deleteFile(file, path) {
     });
 }
 
+/**
+ * Move a single file to an album by HTTP POSTing to a particular path.
+ * 
+ * @param {string} file File name with extension
+ * @param {string} path API path to send request
+ * @returns {Promise<void>}
+ */
+function moveToAlbum(file, path) {
+    return new Promise((resolve) => {
+        const xhr = new XMLHttpRequest();
+        xhr.open("POST", path);
+
+        xhr.onload = () => {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                const thumbnailQuery = `[src="/thumbnail/${file}"]`;
+                const movedThumbnail = document.querySelector(thumbnailQuery);
+                if (movedThumbnail) {
+                    movedThumbnail.closest(".col").remove();
+                }
+
+                resolve();
+            } else {
+                reject(xhr.status);
+            }
+        };
+        xhr.onerror = () => {
+            reject("network error");
+        }
+
+        xhr.send();
+    });
+}
+
 // Some variables are passed here from HTML from Flask.
 // We'll have `albums` on the main page, `album` on an album page, and `videoUrls` on the video page.
 $(document).ready(() => {
-    // Last viewed photo or video in modal
+    /**
+     * Last viewed photo or video in modal
+     * @type {string?}
+     */
     let modalPhotoName = null;
-    // Photo or video selected by checkbox
+    /**
+     * Photo or video selected by checkbox
+     * @type {Set<string>}
+     */
     let selectedItems = new Set();
 
     // Open modal when clicking on a thumbnail
@@ -330,10 +369,10 @@ $(document).ready(() => {
             (file) => uploadFile(file, path),
             2
         )
-            .then(({ successCount, failureCount, totalFiles, errors }) => {
+            .then(({ successCount, failureCount, totalItems, errors }) => {
                 if (failureCount > 0) {
                     console.warn("Some uploads failed:", errors);
-                    alert(`${successCount}/${totalFiles} uploads succeeded`);
+                    alert(`${successCount}/${totalItems} uploads succeeded`);
                     return;
                 }
 
@@ -373,10 +412,10 @@ $(document).ready(() => {
             (file) => deleteFile(file, `${basePath}/${file}`),
             4
         )
-            .then(({ successCount, failureCount, totalFiles, errors }) => {
+            .then(({ successCount, failureCount, totalItems, errors }) => {
                 if (failureCount) {
                     console.warn("Some deletes failed:", errors);
-                    alert(`${successCount}/${totalFiles} deletes succeeded`);
+                    alert(`${successCount}/${totalItems} deletes succeeded`);
                     return;
                 }
 
@@ -390,7 +429,7 @@ $(document).ready(() => {
             });
     });
 
-    // Place photo or video in album
+    // Place photos and videos in album
     $(".photo-action.album-btn").siblings("ul").find("li .dropdown-item").each(function () {
         const li = $(this);
         const album = li.text()
@@ -409,28 +448,35 @@ $(document).ready(() => {
                 return;
             }
 
-            selectedItems.forEach(selectedItem => {
-                fetch(`/api/albums/${album}/${selectedItem}`, { method: "POST" })
-                    .then(response => {
-                        if (response.ok) {
-                            const selectedItemsQuery = `[data-full="/fullsize/${selectedItem}"]`;
-                            const movedThumbnail = document.querySelector(selectedItemsQuery);
-                            if (movedThumbnail) {
-                                movedThumbnail.closest(".col").remove();
-                            }
-                            if (modalPhotoName !== null) {
-                                bootstrap.Modal.getInstance(fullsizeModal).hide();
-                                modalPhotoName = null;
-                            }
-                            selectedItems.delete(selectedItem)
-                        } else {
-                            console.log(response);
-                        }
-                    })
-                    .catch(error => {
-                        console.log(error)
-                    });
-            });
+            $("#operationProgress .progress-bar").addClass("progress-bar-animated");
+            $("#operationProgress").show();
+
+            const basePath = `/api/albums/${album}`;
+            doWithProgressBarWithConcurrency(
+                selectedItems,
+                (file) => moveToAlbum(file, `${basePath}/${file}`),
+                4
+            )
+                .then(({ successCount, failureCount, totalItems, errors }) => {
+                    if (failureCount) {
+                        console.warn("Some moves failed:", errors);
+                        alert(`${successCount}/${totalItems} moves succeeded`);
+                        return;
+                    }
+                    
+                    if (modalPhotoName !== null) {
+                        bootstrap.Modal.getInstance(fullsizeModal).hide();
+                        modalPhotoName = null;
+                    }
+
+                    selectedItems.clear();
+                })
+                .finally(() => {
+                    $("#operationProgress .progress-bar").removeClass("progress-bar-animated");
+                    setTimeout(() => { 
+                        $("#operationProgress").hide(); 
+                    }, 500);
+                });
         });
     });
 

--- a/azurephotos/static/index.js
+++ b/azurephotos/static/index.js
@@ -44,6 +44,93 @@ function isVideo(filename) {
     return VIDEO_EXTENSIONS.has(extension);
 }
 
+function uploadWithConcurrency(files, path, concurrency) {
+    let index = 0;
+    let active = 0;
+
+    const totalFiles = files.length;
+    let successCount = 0;
+    let failureCount = 0;
+    const errors = [];
+
+    function updateProgressBar() {
+        const successPercent = Math.round((successCount / totalFiles) * 100);
+        const failurePercent = Math.round((failureCount / totalFiles) * 100);
+
+        $("#successProgress")
+            .css("width", successPercent + "%")
+            .attr("aria-valuenow", successPercent)
+            .text(`${successCount} / ${totalFiles}`)
+        $("#failureProgress")
+            .css("width", failurePercent + "%")
+            .attr("aria-valuenow", failurePercent)
+            .text(`${failureCount} / ${totalFiles}`)
+    }
+
+    function uploadSingle(file) {
+        return new Promise((resolve) => {
+            const formData = new FormData();
+            formData.append("upload", file);
+
+            const dateTaken = new Date(file.lastModified);
+            formData.append("dateTaken", dateTaken.toISOString());
+
+            const xhr = new XMLHttpRequest();
+            xhr.open("POST", path);
+
+            xhr.onload = () => {
+                if (xhr.status >= 200 && xhr.status < 300) {
+                    successCount++;
+                } else {
+                    failureCount++;
+                    errors.push({
+                        file: file.name,
+                        status: xhr.status
+                    });
+                }
+
+                updateProgressBar();
+                resolve();
+            }
+            xhr.onerror = () => {
+                errors.push({
+                    file: file.name,
+                    status: "network error"
+                });
+
+                updateProgressBar();
+                resolve();
+            }
+
+            xhr.send(formData);
+        });
+    }
+
+    return new Promise((resolve) => {
+        function next() {
+            if (index === files.length && active === 0) {
+                resolve({ successCount, totalFiles, errors });
+                return;
+            }
+
+            while (active < concurrency && index < files.length) {
+                const file = files[index++];
+                active++;
+
+                uploadSingle(file).then(() => {
+                    active--;
+                    next();
+                });
+            }
+        }
+
+        successCount = 0;
+        updateProgressBar();
+
+        next();
+    });
+}
+
 // Some variables are passed here from HTML from Flask.
 // We'll have `albums` on the main page, `album` on an album page, and `videoUrls` on the video page.
 $(document).ready(() => {
@@ -62,7 +149,7 @@ $(document).ready(() => {
 
         // Clear any existing parts of the modal body
         fullsizeModalBody.innerHTML = "";
-        
+
         // Build a new img or video inside the modal body
         if (isVideo(fullSrc)) {
             const video = document.createElement("video");
@@ -94,8 +181,7 @@ $(document).ready(() => {
         const fullsizeModalBody = document.getElementById("fullsizeModalBody");
         const video = fullsizeModalBody.querySelector("video");
 
-        if (video)
-        {
+        if (video) {
             // Try to exit picture-in-picture if active
             try {
                 if (document.pictureInPictureElement) {
@@ -129,57 +215,55 @@ $(document).ready(() => {
         event.preventDefault();
 
         const isAlbum = typeof (album) !== "undefined";
-        const path = isAlbum  ? `/upload/${album}` : `/upload`;
+        const path = isAlbum ? `/upload/${album}` : `/upload`;
 
         const input = document.getElementById("formFileLg");
-        const files = input.files;
-        const formData = new FormData();
-
-        for (let i = 0; i < files.length; i++) {
-            const file = files[i];
-
-            const filename = file.name;
-            if (!isPhoto(filename) && !isVideo(filename)) {
-                alert(`${filename} is not a supported extension`);
-                return;
+        const validFiles = Array.from(input.files).filter(file => {
+            if (!isPhoto(file.name) && !isVideo(file.name)) {
+                alert(`${file.name} is not a supported extension`);
+                return false;
             }
 
-            const fileType = file.type;
-            if (!fileType.startsWith("image/") && !fileType.startsWith("video/")) {
-                alert(`${filename} is not a photo nor a video`);
-                return;
+            if (!file.type.startsWith("image/") && !file.type.startsWith("video/")) {
+                alert(`${file.name} is not a photo nor a video`);
+                return false
             }
 
-            formData.append("upload", file);
+            return true;
+        });
 
-            // Get last modified
-            const dateTaken = new Date(file.lastModified);
-            formData.append("dateTaken", dateTaken.toISOString());
+        if (validFiles.length === 0) {
+            return;
+            // TODO: Should we show some erorr here?
         }
 
-        $("#submitUpload").prop("disabled", true); // disable before upload
-        fetch(path, { method: "POST", body: formData })
-            .then(response => {
-                if (!response.ok) {
-                    alert("Upload failed");
-                    console.log(response);
-                } else {
-                    location.reload();
+        $("#formFileLg").prop("disabled", true);
+        $("#submitUpload").prop("disabled", true);
+        $("#uploadProgress").show();
+
+        uploadWithConcurrency(validFiles, path, 2)
+            .then(({ successCount, totalFiles, errors }) => {
+                if (errors.length > 0) {
+                    console.warn("Some uploads failed:", errors);
+                    alert(`${successCount}/${totalFiles} uploads succeeded`);
+                    return;
                 }
-            })
-            .catch(error => {
-                console.log(error);
+
+                location.reload();
             })
             .finally(() => {
-                $("#submitUpload").prop("disabled", false) // re-enable submit
+                $("#formFileLg").prop("disabled", false);
+                $("#submitUpload").prop("disabled", false);
+                setTimeout(() => { 
+                    $("#uploadProgress").hide(); 
+                }, 500);
             });
-        // Submit button should be re-enabled on page refresh.
     });
 
     // Delete photo or video
     $(".photo-action.delete-btn").click(function (event) {
         const isAlbum = (typeof album) !== "undefined";
-        
+
         // If we clicked the delete button on an unchecked item, add it to selected items
         const selected = event.currentTarget.dataset.selected;
         $(`.photo-checkbox[value='${selected}']`)
@@ -319,7 +403,27 @@ $(document).ready(() => {
 
     // Rename album
     $("#renameAlbumBtn").click(function (_) {
-        const newAlbumName = prompt("Enter new album name");
+        const renameBtn = $(this);
+        const deleteBtn = $("#deleteAlbumBtn");
+        renameBtn.prop("disabled", true);
+        deleteBtn.prop("disabled", true);
+
+        const newAlbumInput = prompt("Enter new album name");
+
+        if (newAlbumInput === null) { // User cancelled rename
+            renameBtn.prop("disabled", false);
+            deleteBtn.prop("disabled", false);
+            return;
+        }
+
+        const newAlbumName = newAlbumInput.trim();
+        if (newAlbumName === "") {
+            alert("Album name cannot be only whitespace");
+            renameBtn.prop("disabled", false);
+            deleteBtn.prop("disabled", false);
+            return;
+        }
+
         fetch(`/api/albums/${album}/rename/${newAlbumName}`, { method: "PUT" })
             .then(response => {
                 if (response.ok) {
@@ -331,6 +435,11 @@ $(document).ready(() => {
             })
             .catch(error => {
                 console.log(error);
+                alert("Rename failed");
+            })
+            .finally(() => {
+                renameBtn.prop("disabled", false);
+                deleteBtn.prop("disabled", false);
             });
     });
 });

--- a/azurephotos/static/index.js
+++ b/azurephotos/static/index.js
@@ -239,6 +239,7 @@ $(document).ready(() => {
 
         $("#formFileLg").prop("disabled", true);
         $("#submitUpload").prop("disabled", true);
+        $("#uploadProgress .progress-bar").addClass("progress-bar-animated");
         $("#uploadProgress").show();
 
         uploadWithConcurrency(validFiles, path, 2)
@@ -254,6 +255,7 @@ $(document).ready(() => {
             .finally(() => {
                 $("#formFileLg").prop("disabled", false);
                 $("#submitUpload").prop("disabled", false);
+                $("#uploadProgress .progress-bar").removeClass("progress-bar-animated");
                 setTimeout(() => { 
                     $("#uploadProgress").hide(); 
                 }, 500);

--- a/azurephotos/templates/album.html
+++ b/azurephotos/templates/album.html
@@ -2,7 +2,7 @@
 
 {% block jsinit %}
 <script type="text/javascript">
-  const album = {{album | tojson}};
+  let album = {{album | tojson}};
 </script>
 {% endblock %}
 

--- a/azurephotos/templates/base.html
+++ b/azurephotos/templates/base.html
@@ -43,14 +43,14 @@
       <button class="btn btn-primary" type="submit" id="submitUpload">Submit</button>
     </form>
     <div class="progress" id="uploadProgress" style="display: none;">
-      <div class="progress-bar progress-bar-striped progress-bar-animated bg-success"
+      <div class="progress-bar progress-bar-striped bg-success"
         role="progressbar"
         id="successProgress"
         style="width: 0%;"
         aria-valuenow="0"
         aria-valuemin="0"
         aria-valuemax="100"></div>
-        <div class="progress-bar progress-bar-striped progress-bar-animated bg-danger"
+        <div class="progress-bar progress-bar-striped bg-danger"
         role="progressbar"
         id="failureProgress"
         style="width: 0%;"

--- a/azurephotos/templates/base.html
+++ b/azurephotos/templates/base.html
@@ -42,7 +42,7 @@
         multiple="true" name="upload" />
       <button class="btn btn-primary" type="submit" id="submitUpload">Submit</button>
     </form>
-    <div class="progress" id="uploadProgress" style="display: none;">
+    <div class="progress" id="operationProgress" style="display: none;">
       <div class="progress-bar progress-bar-striped bg-success"
         role="progressbar"
         id="successProgress"

--- a/azurephotos/templates/base.html
+++ b/azurephotos/templates/base.html
@@ -38,10 +38,26 @@
     <form class="mb-3" id="uploadForm">
       <!-- TODO: Submit request without refreshing page. Would probably have to update DOM to include new image -->
       <label for="formFile">File</label>
-      <input class="form-control form-control-lg" id="formFileLg" type="file" accept="image/*,video/*" required="true" multiple="true"
-        name="upload" />
+      <input class="form-control form-control-lg" id="formFileLg" type="file" accept="image/*,video/*" required="true"
+        multiple="true" name="upload" />
       <button class="btn btn-primary" type="submit" id="submitUpload">Submit</button>
     </form>
+    <div class="progress" id="uploadProgress" style="display: none;">
+      <div class="progress-bar progress-bar-striped progress-bar-animated bg-success"
+        role="progressbar"
+        id="successProgress"
+        style="width: 0%;"
+        aria-valuenow="0"
+        aria-valuemin="0"
+        aria-valuemax="100"></div>
+        <div class="progress-bar progress-bar-striped progress-bar-animated bg-danger"
+        role="progressbar"
+        id="failureProgress"
+        style="width: 0%;"
+        aria-valuenow="0"
+        aria-valuemin="0"
+        aria-valuemax="100"></div>
+    </div>
   </div>
   <hr />
   {% endblock %}
@@ -95,4 +111,5 @@
 
   <script src="/static/index.js"></script>
 </body>
+
 </html>


### PR DESCRIPTION
Fixes #35. Fixes #52. Fixes #49.

The main changes are
- Reuse storage clients in app config instead of creating a new one each time. This reduces the number of roundtrips needed between the app and Azure. The clients themselves should take care of updating their credentials.
-  Use ThreadPoolExecutors to concurrently upload the fullsize data and thumbnail. These operations are independent.
- Send uploads one at a time instead of in one giant attempt. This avoids possibilities of timeouts for uploading large collections of items.
- Add progress bars giving success and failure counts for operations that may have multiple files selected in the UI: upload, delete, and move to album.