### PR TITLE
Increase upload limit to 1GB; Fix concurrency bug

### DIFF
--- a/azurephotos/app.py
+++ b/azurephotos/app.py
@@ -33,7 +33,7 @@ def create_app() -> Flask:
             thumbnails_container_client=thumbnails_container_client,
             albums_table_client=albums_table_client,
             SEND_FILE_MAX_AGE_DEFAULT=86400,
-            MAX_CONTENT_LENGTH=200 * 1024 * 1024,  # 200 MB
+            MAX_CONTENT_LENGTH=1 * 1024 * 1024 * 1024,  # 1 GB
         )
         for blueprint in view.blueprints:
             app.register_blueprint(blueprint)

--- a/azurephotos/src/api/videos.py
+++ b/azurephotos/src/api/videos.py
@@ -57,8 +57,9 @@ def upload(file: FileStorage, date_taken: datetime) -> str:
     file_size = os.path.getsize(temp_path)                                  
 
     try:
+        static_folder = str(current_app.static_folder)
         def upload_thumbnail(client: ContainerClient) -> None:
-            thumbnail_bytes = compute_thumbnail(temp_path)
+            thumbnail_bytes = compute_thumbnail(temp_path, static_folder)
             _ = client.upload_blob(
                 name=f"{save_filename}.webp",
                 data=thumbnail_bytes,

--- a/azurephotos/src/lib/thumbnails.py
+++ b/azurephotos/src/lib/thumbnails.py
@@ -1,4 +1,3 @@
-from flask import current_app
 from io import BytesIO
 from PIL import Image, ImageFile, ImageOps
 from PIL.Image import DecompressionBombError
@@ -7,7 +6,6 @@ from typing import IO
 import os
 import shutil
 import subprocess
-import tempfile
 
 WIDTH = 384
 HEIGHT = 384
@@ -104,7 +102,7 @@ def thumbnail(photo_bytes: IO[bytes]) -> BytesIO:
     except DecompressionBombError:
         raise ValueError("Image is too large")
 
-def video_thumbnail(video_path: str) -> bytes:
+def video_thumbnail(video_path: str, static_folder: str) -> bytes:
     """
     Create a compressed thumbnail of a video.
 
@@ -121,7 +119,7 @@ def video_thumbnail(video_path: str) -> bytes:
         raise Exception("Cannot find ffmpeg")
     
     # find video icon
-    video_icon_path = os.path.join(str(current_app.static_folder), "video_icon.png")
+    video_icon_path = os.path.join(static_folder, "video_icon.png")
     if not os.path.exists(video_icon_path):
         raise Exception("Cannot find video icon")
 


### PR DESCRIPTION
I have a few minutes of 4K video where the largest file is ~800MB. Increasing the limit. Uploading these larger files also exposed a bug with using the app context across different threads. Probably not noticed before as videos were short enough to always do tasks serially.